### PR TITLE
feat(string): add helper subscript methods to slice a string using Int

### DIFF
--- a/FueledUtils/StringExtensions.swift
+++ b/FueledUtils/StringExtensions.swift
@@ -30,7 +30,7 @@ public extension String {
 		get {
 			let i = stringIndex(range.lowerBound)
 			let j = stringIndex(range.upperBound)
-			return self[i...j].string
+			return String(self[i...j])
 		}
 	}
 	
@@ -39,7 +39,7 @@ public extension String {
 		get {
 			let i = stringIndex(range.lowerBound)
 			let j = stringIndex(range.upperBound)
-			return self[i..<j].string
+			return String(self[i..<j])
 		}
 	}
 	
@@ -47,7 +47,7 @@ public extension String {
 	public subscript(_ range: PartialRangeThrough<Int>) -> String {
 		get {
 			let j = stringIndex(range.upperBound)
-			return prefix(through: j).string
+			return String(prefix(through: j))
 		}
 	}
 	
@@ -55,7 +55,7 @@ public extension String {
 	public subscript(_ range: PartialRangeUpTo<Int>) -> String {
 		get {
 			let j = stringIndex(range.upperBound)
-			return prefix(upTo: j).string
+			return String(prefix(upTo: j))
 		}
 	}
 	
@@ -63,7 +63,7 @@ public extension String {
 	public subscript(_ range: PartialRangeFrom<Int>) -> String {
 		get {
 			let i = stringIndex(range.lowerBound)
-			return suffix(from: i).string
+			return String(suffix(from: i))
 		}
 	}
 	
@@ -72,7 +72,3 @@ public extension String {
 	}
 }
 
-public extension Substring {
-	
-	public var string: String { return String(self) }
-}

--- a/FueledUtils/StringExtensions.swift
+++ b/FueledUtils/StringExtensions.swift
@@ -28,8 +28,8 @@ public extension String {
 	// 2...5
 	public subscript(_ range: CountableClosedRange<Int>) -> String {
 		get {
-			let i = index(startIndex, offsetBy: range.lowerBound)
-			let j = index(startIndex, offsetBy: range.upperBound)
+			let i = stringIndex(range.lowerBound)
+			let j = stringIndex(range.upperBound)
 			return self[i...j].string
 		}
 	}
@@ -37,8 +37,8 @@ public extension String {
 	// 2..<5
 	public subscript(_ range: CountableRange<Int>) -> String {
 		get {
-			let i = index(startIndex, offsetBy: range.lowerBound)
-			let j = index(startIndex, offsetBy: range.upperBound)
+			let i = stringIndex(range.lowerBound)
+			let j = stringIndex(range.upperBound)
 			return self[i..<j].string
 		}
 	}
@@ -46,28 +46,29 @@ public extension String {
 	// ...5
 	public subscript(_ range: PartialRangeThrough<Int>) -> String {
 		get {
-			let i = startIndex
-			let j = index(startIndex, offsetBy: range.upperBound)
-			return self[i...j].string
+			let j = stringIndex(range.upperBound)
+			return prefix(through: j).string
 		}
 	}
 	
 	// ..<5
 	public subscript(_ range: PartialRangeUpTo<Int>) -> String {
 		get {
-			let i = startIndex
-			let j = index(startIndex, offsetBy: range.upperBound)
-			return self[i..<j].string
+			let j = stringIndex(range.upperBound)
+			return prefix(upTo: j).string
 		}
 	}
 	
 	// 5...
 	public subscript(_ range: PartialRangeFrom<Int>) -> String {
 		get {
-			let i = index(startIndex, offsetBy: range.lowerBound)
-			let j = endIndex
-			return self[i...j].string
+			let i = stringIndex(range.lowerBound)
+			return suffix(from: i).string
 		}
+	}
+	
+	public func stringIndex(_ idx: Int) -> String.Index {
+		return index(startIndex, offsetBy: idx)
 	}
 }
 

--- a/FueledUtils/StringExtensions.swift
+++ b/FueledUtils/StringExtensions.swift
@@ -24,4 +24,54 @@ public extension String {
 			}
 		} while range != nil
 	}
+	
+	// 2...5
+	public subscript(_ range: CountableClosedRange<Int>) -> String {
+		get {
+			let i = index(startIndex, offsetBy: range.lowerBound)
+			let j = index(startIndex, offsetBy: range.upperBound)
+			return self[i...j].string
+		}
+	}
+	
+	// 2..<5
+	public subscript(_ range: CountableRange<Int>) -> String {
+		get {
+			let i = index(startIndex, offsetBy: range.lowerBound)
+			let j = index(startIndex, offsetBy: range.upperBound)
+			return self[i..<j].string
+		}
+	}
+	
+	// ...5
+	public subscript(_ range: PartialRangeThrough<Int>) -> String {
+		get {
+			let i = startIndex
+			let j = index(startIndex, offsetBy: range.upperBound)
+			return self[i...j].string
+		}
+	}
+	
+	// ..<5
+	public subscript(_ range: PartialRangeUpTo<Int>) -> String {
+		get {
+			let i = startIndex
+			let j = index(startIndex, offsetBy: range.upperBound)
+			return self[i..<j].string
+		}
+	}
+	
+	// 5...
+	public subscript(_ range: PartialRangeFrom<Int>) -> String {
+		get {
+			let i = index(startIndex, offsetBy: range.lowerBound)
+			let j = endIndex
+			return self[i...j].string
+		}
+	}
+}
+
+public extension Substring {
+	
+	public var string: String { return String(self) }
 }


### PR DESCRIPTION
After this PR, we can slice a string using `Int` than `String.Index`

```swift
let name = "Ritesh Gupta"
let subName = name[2...5]
```

Currently the similar result is extremely messy,

```swift
let name = "Ritesh Gupta"
let startIdx = name.index(name.startIndex, offsetBy: 2)
let endIdx = name.index(name.startIndex, offsetBy: 5)
let subName = name[startIdx...endIdx]
```