### PR TITLE
Keyboard inset helper update

### DIFF
--- a/FueledUtils.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/FueledUtils.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/FueledUtils/KeyboardInsetHelper.swift
+++ b/FueledUtils/KeyboardInsetHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ReactiveSwift
 import UIKit
 
 /// Binds keyboard appearance and metrics to scroll view content and scroll bar insets and/or a layout constraint \
@@ -14,8 +15,14 @@ open class KeyboardInsetHelper: NSObject {
 	/// When the keyboard appears or disappears, the constraint's constant will be set to the distance between the bottom of the \
 	/// reference view and the top of the keyboard but no less than `baseInset`.
 	@IBOutlet public weak var constraint: NSLayoutConstraint?
+	/// This property is automatically updated based on the current inset calculated by the inset helper.
+	/// It it changed right before the referenceView's is called.
+	public let keyboardInset: Property<CGFloat>
+
+	private let keyboardInsetMutable = MutableProperty<CGFloat>(0.0)
 
 	public override init() {
+		self.keyboardInset = Property(self.keyboardInsetMutable)
 		super.init()
 		let nc = NotificationCenter.default
 		nc.addObserver(
@@ -65,6 +72,7 @@ open class KeyboardInsetHelper: NSObject {
 		scrollView?.contentInset.bottom = inset
 		scrollView?.scrollIndicatorInsets.bottom = inset
 		constraint?.constant = inset
+		keyboardInsetMutable.value = inset
 		referenceView?.layoutIfNeeded()
 	}
 }

--- a/FueledUtils/KeyboardInsetHelper.swift
+++ b/FueledUtils/KeyboardInsetHelper.swift
@@ -34,6 +34,12 @@ open class KeyboardInsetHelper: NSObject {
 		nc.addObserver(
 			self,
 			selector: #selector(handleKeyboardNotification(_:)),
+			name: NSNotification.Name.UIKeyboardWillChangeFrame,
+			object: nil
+		)
+		nc.addObserver(
+			self,
+			selector: #selector(handleKeyboardNotification(_:)),
 			name: NSNotification.Name.UIKeyboardWillHide,
 			object: nil
 		)
@@ -42,6 +48,7 @@ open class KeyboardInsetHelper: NSObject {
 	deinit {
 		let nc = NotificationCenter.default
 		nc.removeObserver(self, name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+		nc.removeObserver(self, name: NSNotification.Name.UIKeyboardWillChangeFrame, object: nil)
 		nc.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
 	}
 


### PR DESCRIPTION
This PR adds 2 features to the existing `KeyboardInsetHelper` implementation:
- The first is exposing a `keyboardInset` property that allows user of the helper to combine the current inset of the keyboard with other reactive property. For example, if you have a button that's supposed to be _only_ displayed when a field is validated, but should also be on top of the keyboard - you can simply `combineLatest(<isValidated>, <yourHelper>.keyboardInset)` and do your animation inside. Since `UIView.animateWithDuration`'s parameters are inherited (if not explicitely specify), you can specify another one inside.
- It adds support for `UIKeyboardDidChangeFrameNotification`, which is triggered when the keyboard changes frame