### PR TITLE
Implement gradient view

### DIFF
--- a/FueledUtils.playground/Contents.swift
+++ b/FueledUtils.playground/Contents.swift
@@ -1,0 +1,8 @@
+import FueledUtils
+import PlaygroundSupport
+import UIKit
+
+let gradientView = GradientView(frame: CGRect(origin: .zero, size: CGSize(width: 200.0, height: 200.0)))
+
+gradientView.type = .linear(direction: CGPoint(x: 0.0, y: 0.5))
+gradientView.definition = .custom([(.black, 0.0), (.red, 0.5), (.blue, 1.0)])

--- a/FueledUtils.playground/Contents.swift
+++ b/FueledUtils.playground/Contents.swift
@@ -2,7 +2,7 @@ import FueledUtils
 import PlaygroundSupport
 import UIKit
 
-let gradientView = GradientView(frame: CGRect(origin: .zero, size: CGSize(width: 200.0, height: 200.0)))
+let gradientView = GradientView(frame: CGRect(origin: .zero, size: CGSize(width: 500.0, height: 500.0)))
 
-gradientView.type = .linear(direction: CGPoint(x: 0.0, y: 0.5))
+gradientView.type = .radial(startCenter: CGPoint(x: 0.5, y: 0.5), startRadius: 10.0, endCenter: CGPoint(x: 0.5, y: 0.5), endRadius: 50.0)
 gradientView.definition = .custom([(.black, 0.0), (.red, 0.5), (.blue, 1.0)])

--- a/FueledUtils.playground/contents.xcplayground
+++ b/FueledUtils.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' executeOnSourceChanges='false'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/FueledUtils.xcodeproj/project.pbxproj
+++ b/FueledUtils.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		02DF8ECB1E6464AB009AB29C /* ReactiveLifetimeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF8ECA1E6464AB009AB29C /* ReactiveLifetimeProvider.swift */; };
 		02E626091D340F0C0041E512 /* LoadingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E626081D340F0C0041E512 /* LoadingState.swift */; };
 		35996E0F1F55C3E1004D6AC0 /* FoundationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35996E0E1F55C3E1004D6AC0 /* FoundationExtensions.swift */; };
+		DFA57F0621E7A64200467647 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA57F0521E7A64200467647 /* GradientView.swift */; };
 		F4A619551F47263100777BB2 /* CollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A619541F47263100777BB2 /* CollectionExtensions.swift */; };
 /* End PBXBuildFile section */
 
@@ -57,6 +58,7 @@
 		02DF8ECA1E6464AB009AB29C /* ReactiveLifetimeProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveLifetimeProvider.swift; sourceTree = "<group>"; };
 		02E626081D340F0C0041E512 /* LoadingState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingState.swift; sourceTree = "<group>"; };
 		35996E0E1F55C3E1004D6AC0 /* FoundationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationExtensions.swift; sourceTree = "<group>"; };
+		DFA57F0521E7A64200467647 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		F4A619541F47263100777BB2 /* CollectionExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -125,6 +127,7 @@
 				02DE3C3B1D258FD1002B58E2 /* StringExtensions.swift */,
 				02DE3C3A1D258FD1002B58E2 /* UIExtensions.swift */,
 				35996E0E1F55C3E1004D6AC0 /* FoundationExtensions.swift */,
+				DFA57F0521E7A64200467647 /* GradientView.swift */,
 			);
 			path = FueledUtils;
 			sourceTree = "<group>";
@@ -210,6 +213,7 @@
 			files = (
 				02DE3C4A1D25952A002B58E2 /* Regex.swift in Sources */,
 				02DE3C4D1D259628002B58E2 /* ButtonWithTitleAdjustment.swift in Sources */,
+				DFA57F0621E7A64200467647 /* GradientView.swift in Sources */,
 				02DE3C421D258FD1002B58E2 /* StringExtensions.swift in Sources */,
 				02DE3C501D259966002B58E2 /* SetRootViewController.swift in Sources */,
 				02DE3C441D25928F002B58E2 /* KeyboardInsetHelper.swift in Sources */,

--- a/FueledUtils.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/FueledUtils.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/FueledUtils.xcworkspace/contents.xcworkspacedata
+++ b/FueledUtils.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,9 @@
       location = "group:FueledUtils.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:FueledUtils.playground">
+   </FileRef>
+   <FileRef
       location = "group:Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa.xcodeproj">
    </FileRef>
    <FileRef

--- a/FueledUtils/GradientView.swift
+++ b/FueledUtils/GradientView.swift
@@ -79,6 +79,19 @@ public final class GradientView: UIView {
 		/// about what this property refers to.
 		///
 		case linear(direction: CGPoint)
+		///
+		/// Defines a radial gradient type, starting at the specified center with the given initial radius, and expanding/reducing to the specified center and final radius.
+		/// When used with `GradientView`, `startCenter` and `endCenter` is scaled to the bounds of the view. `startRadius` and `endRadius` are not scaled.
+		///
+		/// ## Examples
+		/// - `.radial(startCenter: CGPoint(x: 0.5, y: 0.5), startRadius: 10.0, endCenter: CGPoint(x: 0.5, y: 0.5), endRadius: 200.0)`: Define a radial gradient that starts
+		///   in the center of the view with an initial radius of 10, and expands to a radius of 200 without changing its center.
+		/// - `.radial(startCenter: CGPoint(x: 0.0, y: 0.5), startRadius: 200.0, endCenter: CGPoint(x: 1.0, y: 0.5), endRadius: 10.0)`: Define a radial gradient that starts
+		///   in the left edge of the view centered vertically with an initial radius of 200, and reduce to a radius of 50 to the right-most edge centered vertically.
+		///
+		/// - Note: When using different centers for a radial gradient, the resulting gradient might be unexpected.
+		///
+		case radial(startCenter: CGPoint, startRadius: CGFloat, endCenter: CGPoint, endRadius: CGFloat)
 	}
 
 	///
@@ -191,6 +204,26 @@ public final class GradientView: UIView {
 					x: baseEnd.x < 0.0 ? 0.0 : baseEnd.x,
 					y: baseEnd.y < 0.0 ? 0.0 : baseEnd.y
 				),
+				options: [
+					.drawsBeforeStartLocation,
+					.drawsAfterEndLocation,
+				]
+			)
+		case .radial(let startCenter, let startRadius, let endCenter, let endRadius):
+			let startCenter = CGPoint(
+				x: self.bounds.size.width * startCenter.x,
+				y: self.bounds.size.height * startCenter.y
+			)
+			let endCenter = CGPoint(
+				x: self.bounds.size.width * endCenter.x,
+				y: self.bounds.size.height * endCenter.y
+			)
+			context.drawRadialGradient(
+				gradient,
+				startCenter: startCenter,
+				startRadius: startRadius,
+				endCenter: endCenter,
+				endRadius: endRadius,
 				options: [
 					.drawsBeforeStartLocation,
 					.drawsAfterEndLocation,

--- a/FueledUtils/GradientView.swift
+++ b/FueledUtils/GradientView.swift
@@ -1,0 +1,104 @@
+import UIKit
+
+public final class GradientView: UIView {
+	var gradientInfo: [(color: UIColor, location: CGFloat)] = [] {
+		didSet {
+			self.setNeedsDisplay()
+		}
+	}
+
+	@IBInspectable var isVertical: Bool = true {
+		didSet {
+			if self.isVertical != oldValue {
+				self.setNeedsDisplay()
+			}
+		}
+	}
+
+	override init(frame: CGRect) {
+		super.init(frame: frame)
+		self.commonInit()
+	}
+
+	required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+		self.commonInit()
+	}
+
+	private func commonInit() {
+		self.contentMode = .redraw
+		// https://stackoverflow.com/a/43898524/3605958
+		// The background color must be set to a non-nil value or drawRect(_:) will not render the gradient properly
+		self.backgroundColor = UIColor.clear
+	}
+
+	override public func draw(_ rect: CGRect) {
+		let context = UIGraphicsGetCurrentContext()!
+		let colors = self.gradientInfo.map { $0.color.cgColor }
+		var locations: [CGFloat] = self.gradientInfo.map { $0.location }
+		let colorSpace = CGColorSpaceCreateDeviceRGB()
+		let gradient = CGGradient(colorsSpace: colorSpace, colors: colors as CFArray, locations: &locations)!
+		context.drawLinearGradient(
+			gradient,
+			start: .zero,
+			end: CGPoint(
+				x: self.isVertical ? 0.0 : self.bounds.size.width,
+				y: self.isVertical ? self.bounds.size.height : 0.0
+			),
+			options: []
+		)
+	}
+}
+
+public final class SimpleGradientView: UIView {
+	private lazy var gradientView: GradientView = {
+		$0.gradientInfo = [
+			(.white, 0.0),
+			(.black, 1.0),
+		]
+		return $0
+	}(GradientView())
+
+	@IBInspectable
+	public var startColor: UIColor {
+		get {
+			return UIColor(cgColor: self.gradientView.gradientInfo[0].color.cgColor)
+		}
+		set {
+			self.gradientView.gradientInfo[0].color = newValue
+		}
+	}
+
+	@IBInspectable
+	public var endColor: UIColor {
+		get {
+			return UIColor(cgColor: self.gradientView.gradientInfo[1].color.cgColor)
+		}
+		set {
+			self.gradientView.gradientInfo[1].color = newValue
+		}
+	}
+
+	@IBInspectable var isVertical: Bool {
+		get {
+			return self.gradientView.isVertical
+		}
+		set {
+			self.gradientView.isVertical = newValue
+		}
+	}
+
+	override public init(frame: CGRect) {
+		super.init(frame: frame)
+		self.commonInit()
+	}
+
+	public required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+		self.commonInit()
+	}
+
+	private func commonInit() {
+		self.addAndFitSubview(self.gradientView)
+	}
+}


### PR DESCRIPTION
~This adds 2 classes for gradients, one that allows any kind of gradients (`GradientView`) and another one that's a simplified version usable directly within IB (`SimpleGradientView`).
The method used in this class prevents the [Mach Bands](https://en.wikipedia.org/wiki/Mach_bands) usually seen otherwise.~
The PR has been updated to only use one class `GradientView`, that can be easily used in IB and also allows to do radial gradient.
Resolves #10 