### PR TITLE
Implement extensions not related to RAC

### DIFF
--- a/FueledUtils.xcodeproj/project.pbxproj
+++ b/FueledUtils.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		02E626091D340F0C0041E512 /* LoadingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E626081D340F0C0041E512 /* LoadingState.swift */; };
 		35996E0F1F55C3E1004D6AC0 /* FoundationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35996E0E1F55C3E1004D6AC0 /* FoundationExtensions.swift */; };
 		DFA57F0621E7A64200467647 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA57F0521E7A64200467647 /* GradientView.swift */; };
+		F40C574821F9182B0006FB3F /* TransferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40C574721F9182B0006FB3F /* TransferState.swift */; };
 		F4A619551F47263100777BB2 /* CollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A619541F47263100777BB2 /* CollectionExtensions.swift */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +60,7 @@
 		02E626081D340F0C0041E512 /* LoadingState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingState.swift; sourceTree = "<group>"; };
 		35996E0E1F55C3E1004D6AC0 /* FoundationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationExtensions.swift; sourceTree = "<group>"; };
 		DFA57F0521E7A64200467647 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
+		F40C574721F9182B0006FB3F /* TransferState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferState.swift; sourceTree = "<group>"; };
 		F4A619541F47263100777BB2 /* CollectionExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -112,6 +114,7 @@
 				F4A619541F47263100777BB2 /* CollectionExtensions.swift */,
 				02DE3C561D25A24B002B58E2 /* DecoratingTextFieldDelegate.swift */,
 				02DE3C541D259FA9002B58E2 /* DimmingButton.swift */,
+				F40C574721F9182B0006FB3F /* TransferState.swift */,
 				35996E0E1F55C3E1004D6AC0 /* FoundationExtensions.swift */,
 				02DE3C451D25933E002B58E2 /* HairlineView.swift */,
 				02DE3C431D25928F002B58E2 /* KeyboardInsetHelper.swift */,
@@ -231,6 +234,7 @@
 				02DE3C3E1D258FD1002B58E2 /* SequenceExtensions.swift in Sources */,
 				02DE3C3F1D258FD1002B58E2 /* SignalingAlert.swift in Sources */,
 				02DE3C551D259FA9002B58E2 /* DimmingButton.swift in Sources */,
+				F40C574821F9182B0006FB3F /* TransferState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FueledUtils/CollectionExtensions.swift
+++ b/FueledUtils/CollectionExtensions.swift
@@ -39,4 +39,11 @@ public extension Collection {
 		}
 		return self[index]
 	}
+
+	///
+	/// Returns a collection with same element, and information as to whether the element is the first or the last, or both.
+	///
+	public func withPositionInformation() -> [(element: Self.Element, isFirstElement: Bool, isLastElement: Bool)] {
+		return self.enumerated().map { ($0.element, $0.offset == 0, $0.offset == self.count - 1) }
+	}
 }

--- a/FueledUtils/CollectionExtensions.swift
+++ b/FueledUtils/CollectionExtensions.swift
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-public extension Collection {
+extension Collection {
 	///
 	/// **Deprecated**: Please use `getSafely(at:)` instead.
 	///

--- a/FueledUtils/FoundationExtensions.swift
+++ b/FueledUtils/FoundationExtensions.swift
@@ -15,7 +15,7 @@ limitations under the License.
 */
 import Foundation
 
-public extension Bool {
+extension Bool {
 	///
 	/// **Deprecated**: Please use `toggle()` instead.
 	///

--- a/FueledUtils/LoadingState.swift
+++ b/FueledUtils/LoadingState.swift
@@ -67,7 +67,7 @@ public enum LoadingState<Error: Swift.Error> {
 	}
 }
 
-public extension Action {
+extension Action {
 	///
 	/// **Deprecated**: Please use `getSafely(at:)` instead.
 	///

--- a/FueledUtils/RACExtensions.swift
+++ b/FueledUtils/RACExtensions.swift
@@ -127,7 +127,7 @@ extension SignalProtocol {
 	/// - Returns: A signal that sends values that are sent from `self` at least
 	///            `interval` seconds apart.
 	///
-	func minimum(interval: TimeInterval, on scheduler: DateScheduler) -> Signal<Value, Error> {
+	public func minimum(interval: TimeInterval, on scheduler: DateScheduler) -> Signal<Value, Error> {
 		return Signal { observer, disposable in
 			let semaphore = DispatchSemaphore(value: 1)
 			var events: [Signal<Value, Error>.Event] = []
@@ -190,7 +190,7 @@ extension SignalProducerProtocol {
 	///
 	/// See `Signal.minimum` for documentation
 	///
-	func minimum(interval: TimeInterval, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
+	public func minimum(interval: TimeInterval, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
 		return self.producer.lift { $0.minimum(interval: interval, on: scheduler) }
 	}
 }

--- a/FueledUtils/RACExtensions.swift
+++ b/FueledUtils/RACExtensions.swift
@@ -61,7 +61,7 @@ public func transitionContext(
 		}
 }
 
-public extension SignalProtocol {
+extension SignalProtocol {
 	/// The original purpose of this method is to allow triggering animations in response to signal values.
 	///
 	/// - Parameters:
@@ -160,7 +160,7 @@ public extension SignalProtocol {
 	}
 }
 
-public extension SignalProducerProtocol {
+extension SignalProducerProtocol {
 	///
 	/// Returns a SignalProducer which cannot fail. Errors that would be otherwise be sent in the original producer are ignored.
 	///
@@ -195,7 +195,7 @@ public extension SignalProducerProtocol {
 	}
 }
 
-public extension SignalProducer where Error == NoError {
+extension SignalProducer where Error == NoError {
 	public func chain<U>(_ transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, NoError> {
 		return flatMap(.latest, transform)
 	}
@@ -221,7 +221,7 @@ public extension SignalProducer where Error == NoError {
 	}
 }
 
-public extension PropertyProtocol {
+extension PropertyProtocol {
 	public func chain<U>(_ transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, NoError> {
 		return producer.chain(transform)
 	}

--- a/FueledUtils/ReactiveLifetimeProvider.swift
+++ b/FueledUtils/ReactiveLifetimeProvider.swift
@@ -27,7 +27,7 @@ open class Lifetimed: ReactiveLifetimeProvider {
 	}
 }
 
-public extension Reactive where Base: AnyObject, Base: ReactiveLifetimeProvider {
+extension Reactive where Base: AnyObject, Base: ReactiveLifetimeProvider {
 	public var lifetime: Lifetime {
 		return Lifetime(self.base.lifetimeToken)
 	}

--- a/FueledUtils/ScrollViewPage.swift
+++ b/FueledUtils/ScrollViewPage.swift
@@ -15,7 +15,7 @@ limitations under the License.
 */
 import UIKit
 
-public extension UIScrollView {
+extension UIScrollView {
 	///
 	/// **Deprecated**: Please use `currentPage` instead.
 	///

--- a/FueledUtils/SequenceExtensions.swift
+++ b/FueledUtils/SequenceExtensions.swift
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-public extension Sequence {
+extension Sequence {
 	///
 	/// Transforms the sequence into a dictionary grouped by the specified Key type.
 	///

--- a/FueledUtils/SetRootViewController.swift
+++ b/FueledUtils/SetRootViewController.swift
@@ -16,7 +16,7 @@ limitations under the License.
 import Foundation
 import UIKit
 
-public extension UIApplicationDelegate {
+extension UIApplicationDelegate {
 	///
 	/// Switches root view controller avoiding common problems of unintended animations.
 	///

--- a/FueledUtils/StringExtensions.swift
+++ b/FueledUtils/StringExtensions.swift
@@ -38,6 +38,24 @@ extension StringProtocol where Self.Index == String.Index {
 		let allowedCharacters = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~")
 		return self.addingPercentEncoding(withAllowedCharacters: allowedCharacters)!
 	}
+	///
+	/// Returns true if the receiver is empty or if it only contains whitespaces or newlines
+	///
+	public var isBlank: Bool {
+		return self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+	}
+	///
+	/// Returns the receiver if `isEmpty` is `false`, and `nil` if it is `true`
+	///
+	public var nonEmptyValue: Self? {
+		return self.isEmpty ? nil : self
+	}
+	///
+	/// Returns the receiver if `isBlank` is `false`, and `nil` if it is `true`
+	///
+	public var nonBlankValue: Self? {
+		return self.isBlank ? nil : self
+	}
 }
 
 extension String {
@@ -98,5 +116,26 @@ extension String {
 
 	public func stringIndex(_ index: Int) -> Index {
 		return self.index(startIndex, offsetBy: index)
+	}
+}
+
+extension Optional where Wrapped: StringProtocol, Wrapped.Index == String.Index {
+	///
+	/// If the receiver is non-`nil`, returns the result of `StringProtocol.nonBlankValue.isBlank`, otherwise returns `false.
+	///
+	public var isBlank: Bool {
+		return self.map { $0.isBlank } ?? true
+	}
+	///
+	/// If the receiver is non-`nil`, returns the result of `StringProtocol.nonEmptyValue`, otherwise returns `false.
+	///
+	public var nonEmptyValue: Wrapped? {
+		return self.flatMap { $0.nonEmptyValue }
+	}
+	///
+	/// If the receiver is non-`nil`, returns the result of `StringProtocol.nonBlankValue`, otherwise returns `false.
+	///
+	public var nonBlankValue: Wrapped? {
+		return self.flatMap { $0.nonBlankValue }
 	}
 }

--- a/FueledUtils/StringExtensions.swift
+++ b/FueledUtils/StringExtensions.swift
@@ -65,7 +65,7 @@ extension String {
 	public mutating func replaceOccurrences<Target: StringProtocol, Replacement: StringProtocol>(of target: Target, with replacement: Replacement, options: String.CompareOptions = [], locale: Locale? = nil) {
 		var range: Range<Index>?
 		repeat {
-			range = self.range(of: target, options: options, range: range.map { $0.lowerBound..<self.endIndex }, locale: locale)
+			range = self.range(of: target, options: options, range: range.map { self.index($0.lowerBound, offsetBy: replacement.count)..<self.endIndex }, locale: locale)
 			if let range = range {
 				self.replaceSubrange(range, with: replacement)
 			}

--- a/FueledUtils/TransferState.swift
+++ b/FueledUtils/TransferState.swift
@@ -1,0 +1,127 @@
+//
+//  LoadingStatus.swift
+//  AlterraCommon
+//
+//  Created by Stéphane Copin on 10/18/17.
+//  Copyright © 2017 Fueled. All rights reserved.
+//
+
+import Foundation
+import ReactiveSwift
+
+///
+/// Represents a transfer state, either loading or finished.
+/// This is useful to represent a transfer state in percentage or bytes uploaded for example.
+///
+/// It is recommended to define a `typealias` corresponding to your use case that specify at least the `Progress` type, for example:
+/// ```swift
+/// typealias DownloadState<Value> = TransferState<Double, Value>
+/// ```
+/// or
+/// ```swift
+/// typealias DownloadState<Value> = TransferState<(uploadedBytes: UInt64, totalBytes: UInt64)?, Value>
+/// ```
+/// Nothing prevents you to also include the `Value` type in the `typealias`, if possible for your use case.
+///
+public enum TransferState<Progress, Value> {
+	///
+	/// Represents a `loading` state.
+	///
+	case loading(Progress)
+	///
+	/// Represents a `finished` state.
+	///
+	case finished(Value)
+
+	///
+	/// Map a `TransferState` finishing with one `Value` into another, mapping it with the given closure.
+	///
+	/// - Parameters:
+	///   - mapper: Mapper closure how to map the initial value to the mapped value.
+	/// - Returns: A `TransferState` with the mapped value as mapped by the given closure.
+	///
+	public func map<Mapped>(_ mapper: (Value) -> Mapped) -> TransferState<Progress, Mapped> {
+		switch self {
+		case .loading(let progress):
+			return .loading(progress)
+		case .finished(let result):
+			return .finished(mapper(result))
+		}
+	}
+}
+
+extension SignalProtocol {
+	///
+	/// Converts a `Signal` that has a `TransferState` value into a `Signal` only returning a value when `finished()` is received.
+	///
+	public func ignoreLoading<Progress, Value>() -> Signal<Value, Error>
+		where Self.Value == TransferState<Progress, Value>
+	{
+		return self.signal.filterMap { status in
+			switch status {
+			case .loading:
+				return nil
+			case .finished(let result):
+				return result
+			}
+		}
+	}
+
+	///
+	/// Maps a `Signal` for which each value is a `TransferState` into a `TransferState` returning the mapped value.
+	///
+	public func mapFinished<Progress, Value, Mapped>(_ mapper: @escaping (Value) -> Mapped) -> Signal<TransferState<Progress, Mapped>, Error>
+		where Self.Value == TransferState<Progress, Value>
+	{
+		return self.signal.map { $0.map(mapper) }
+	}
+git 
+	///
+	/// Maps a `Signal` for which each value is a `TransferState` into a `TransferState` returning a `SignalProducer` returning the mapped value.
+	///
+	public func flatMapFinished<Progress, Value, Mapped>(_ mapper: @escaping (Value) -> SignalProducer<Mapped, Error>) -> Signal<TransferState<Progress, Mapped>, Error>
+		where Self.Value == TransferState<Progress, Value>
+	{
+		return self.signal.flatMap(.latest) { status -> Signal<TransferState<Progress, Mapped>, Error> in
+			return Signal { observer, disposable in
+				switch status {
+				case .loading(let progress):
+					observer.send(value: .loading(progress))
+				case .finished(let result):
+					disposable += mapper(result)
+						.map { .finished($0) }
+						.start(observer)
+				}
+			}
+		}
+	}
+}
+
+extension SignalProducerProtocol {
+	///
+	/// Converts a `SignalProducer` that has a `TransferState` value into a `SignalProducer` only returning a value when `finished()` is received.
+	///
+	public func ignoreLoading<Progress, Value>() -> SignalProducer<Value, Error>
+		where Self.Value == TransferState<Progress, Value>
+	{
+		return self.producer.lift { $0.ignoreLoading() }
+	}
+
+	///
+	/// Maps a `SignalProducer` for which each value is a `TransferState` into a `TransferState` returning the mapped value.
+	///
+	public func mapFinished<Progress, Value, Mapped>(_ mapper: @escaping (Value) -> Mapped) -> SignalProducer<TransferState<Progress, Mapped>, Error>
+		where Self.Value == TransferState<Progress, Value>
+	{
+		return self.producer.lift { $0.mapFinished(mapper) }
+	}
+
+	///
+	/// Maps a `SignalProducer` for which each value is a `TransferState` into a `TransferState` returning a `SignalProducer` returning the mapped value.
+	///
+	public func flatMapFinished<Progress, Value, Mapped>(_ mapper: @escaping (Value) -> SignalProducer<Mapped, Error>) -> SignalProducer<TransferState<Progress, Mapped>, Error>
+		where Self.Value == TransferState<Progress, Value>
+	{
+		return self.producer.lift { $0.flatMapFinished(mapper) }
+	}
+}

--- a/FueledUtils/TransferState.swift
+++ b/FueledUtils/TransferState.swift
@@ -75,7 +75,7 @@ extension SignalProtocol {
 	{
 		return self.signal.map { $0.map(mapper) }
 	}
-git 
+
 	///
 	/// Maps a `Signal` for which each value is a `TransferState` into a `TransferState` returning a `SignalProducer` returning the mapped value.
 	///

--- a/FueledUtils/UIExtensions.swift
+++ b/FueledUtils/UIExtensions.swift
@@ -267,9 +267,43 @@ extension UIView {
 	}
 }
 
+@available(iOS 9.0, *)
+extension UIStackView {
+	///
+	/// Removes all of the current arranged subviews from the `UIStackView`, optionally
+	/// allowing to remove them from the `UIStackView`'s subviews as well.
+	///
+	/// - Parameters:
+	///   - removeFromHierachy: If `true`, each views is also removed from the receiver using `removeFromSuperview()`.
+	///     If `false`, `removeFromSuperview()` is not called.
+	///
+	func removeArrangedSubviews(removeFromHierachy: Bool) {
+		let arrangedSubviews = self.arrangedSubviews
+		arrangedSubviews.forEach { self.removeArrangedSubview($0, removeFromHierachy: removeFromHierachy) }
+	}
+
+	///
+	/// Removes the given arranged subview from the `UIStackView`, optionally
+	/// allowing to remove it from the `UIStackView`'s subviews as well.
+	///
+	/// - Parameters:
+	///   - view: The arranged subview to remove from the receiver.
+	///   - removeFromHierachy: If `true`, the view is also removed from the receiver using `removeFromSuperview()`.
+	///     If `false`, `removeFromSuperview()` is not called.
+	///
+	func removeArrangedSubview(_ view: UIView, removeFromHierachy: Bool) {
+		if removeFromHierachy {
+			view.removeFromSuperview()
+		} else {
+			// `removeArrangedSubview` doesn't call `removeFromSuperview` for the `view`
+			self.removeArrangedSubview(view)
+		}
+	}
+}
+
 extension UITableView {
 	///
-	/// Deselect given rows, optionally with an animation.
+	/// Deselect the given rows, optionally with an animation.
 	///
 	/// - Parameters:
 	///   - indexPaths: The rows to deselect.
@@ -306,7 +340,7 @@ extension UITableView {
 
 extension UICollectionView {
 	///
-	/// Deselect given items, optionally with an animation.
+	/// Deselect the given items, optionally with an animation.
 	///
 	/// - Parameters:
 	///   - indexPaths: The items to deselect.

--- a/FueledUtils/UIExtensions.swift
+++ b/FueledUtils/UIExtensions.swift
@@ -164,6 +164,64 @@ public extension UIView {
 			self.drawHierarchy(in: self.bounds, afterScreenUpdates: afterScreenUpdates)
 		}
 	}
+
+	///
+	/// Apply a shadow with the parameters that can be specified in the Sketch application.
+	/// This methods internally updates the following properties of the backing `CALayer` (`self.layer`):
+	/// - `CALayer.shadowColor`
+	/// - `CALayer.shadowOpacity`
+	/// - `CALayer.shadowOffset`
+	/// - `CALayer.shadowRadius`
+	/// - `CALayer.shadowPath`
+	///
+	/// When using this method, it is recommended **not** to modify any of these properties to avoid unexpected results.
+	///
+	/// - Parameters:
+	///   - color: The color of the shadow, as specified in Sketch (usually without the alpha component, specified afterwards)
+	///   - alpha: The alpha (opacity) of the shadow, as specified in Sketch
+	///   - xAxis: The X direction of the shadow, as specified in Sketch
+	///   - yAxis: The y direction of the shadow, as specified in Sketch
+	///   - blur: The blur offset of the shadow, as specified in Sketch
+	///   - spread: The spread of the shadow, as specified in Sketch.
+	///   - path: The path the shadow should use. If `nil`, it defaults to a rectangle of the size of the bounds of the receiver
+	///
+	/// - Note: It is safe to call this method multiple times without calling `removeSketchShadow` between each calls.
+	///
+	func applySketchShadow(
+		color: UIColor = .black,
+		alpha: Float = 0.5,
+		xAxis: CGFloat = 0.0,
+		yAxis: CGFloat = 2.0,
+		blur: CGFloat = 4.0,
+		spread: CGFloat = 0.0,
+		path: CGPath? = nil)
+	{
+		self.layer.shadowColor = color.cgColor
+		self.layer.shadowOpacity = alpha
+		self.layer.shadowOffset = CGSize(width: xAxis, height: yAxis)
+		self.layer.shadowRadius = blur / 2.0
+
+		if path == nil || spread == 0.0 {
+			self.layer.shadowPath = nil
+		} else {
+			let scaleFactor = (self.bounds.size.width + spread * 2.0) / self.bounds.size.width
+			let path = (path.map { UIBezierPath(cgPath: $0) } ?? UIBezierPath(rect: self.bounds))
+			path.apply(CGAffineTransform(scaleX: scaleFactor, y: scaleFactor))
+			self.layer.shadowPath = path.cgPath
+		}
+	}
+
+	///
+	/// Remove a shadow as set by `applySketchShadow`
+	/// This method will reset any shadows sets on the backing layer, _even it wasn't applied by `applySketchShadow`
+	///
+	func removeSketchShadow() {
+		self.layer.shadowColor = nil
+		self.layer.shadowOpacity = 0.0
+		self.layer.shadowOffset = .zero
+		self.layer.shadowRadius = 0.0
+		self.layer.shadowPath = nil
+	}
 }
 
 public extension UITableView {

--- a/FueledUtils/UIExtensions.swift
+++ b/FueledUtils/UIExtensions.swift
@@ -433,11 +433,18 @@ extension UIImage {
 
 	///
 	/// Apply the given tint to the image. The rendering mode is kept the same.
+	/// This method takes the rgb values of each pixels in the image, and replace them with the color
+	/// given as parameter. The alpha value of each pixels is kept the same.
 	/// The resulting image will be made resizable whether it was originally or not,
 	/// with `capInsets` set as the cap insets, and `resizingMode` as its resizing mode.
 	///
+	/// The behavior of this method is similar to using the `UIImage` with a `.alwaysTemplate` rendering mode
+	/// and using a `tintColor` when displaying the `UIImage` in an `UIImageView`.
+	///
+	/// - SeeAlso: `withColor(_:)`
+	///
 	/// - Parameters:
-	///   - color: The color to apply to the receiver.
+	///   - tint: The tint to apply to the receiver.
 	///
 	public func withTint(_ tint: UIColor) -> UIImage {
 		let image = UIImage.draw(size: self.size, scale: self.scale) { _ in
@@ -446,6 +453,32 @@ extension UIImage {
 			self.draw(at: .zero, blendMode: .destinationIn, alpha: 1)
 		}
 		return image.resizableImage(withCapInsets: self.capInsets, resizingMode: self.resizingMode).withRenderingMode(self.renderingMode)
+	}
+
+	///
+	/// Apply the given color to the image. The rendering mode is kept the same.
+	/// This method keeps the brightness of all pixels the same, but updates the saturation and hue
+	/// to that of the given color.
+	///
+	/// In other words, this methods can be used to color grayscale images or tint images without loosing
+	/// contrast information.
+	///
+	/// - SeeAlso: `withTint(_:)`
+	///
+	/// - Parameters:
+	///   - color: The color to apply to the receiver.
+	///
+	public func withColor(_ color: UIColor) -> UIImage {
+		return UIImage.draw(
+			size: self.size,
+			graphics: { context in
+				let rect = CGRect(origin: .zero, size: self.size)
+				self.draw(in: rect, blendMode: .color, alpha: 1.0)
+				context.setFillColor(color.cgColor)
+				context.setBlendMode(.color)
+				context.fill(rect)
+			}
+		).withRenderingMode(self.renderingMode)
 	}
 
 	///

--- a/FueledUtils/UIExtensions.swift
+++ b/FueledUtils/UIExtensions.swift
@@ -16,7 +16,50 @@ limitations under the License.
 import Foundation
 import UIKit
 
-public extension UIColor {
+extension CGSize {
+	///
+	/// Scale the recipient to the given size, according to the specified content mode.
+	///
+	/// This methods is best use in combination of `UIImage.resized`, to make sure that the image
+	/// is scaled properly for your needs.
+	///
+	/// - Parameters:
+	///   - size: The size to scale the receiver to.
+	///   - contentMode: The content mode to use when scaling the receiver.
+	///     If `contentMode` is `.scaleAspectFill`, the method will try to maximize the lowest dimension of the receiver
+	///     to the lowest dimension of `size`.
+	///     If `contentMode` is `.scaleAspectFit`, the method will try to maximize the highest dimension of the receiver
+	///     to the lowest dimension of `size`.
+	///     If the `contentMode` is `redraw` or `scaleToFill` (the default), `size` is returned.
+	///     In all other cases, the receiver is returned and `size` is ignored.
+	/// - Returns: The scaled size as specified by the parameters.
+	///
+	func scaled(to size: CGSize, contentMode: UIView.ContentMode = .scaleToFill) -> CGSize {
+		switch contentMode {
+		case .redraw,
+				 .scaleToFill:
+			return size
+		case .scaleAspectFill:
+			let aspectRatio = self.width / self.height
+			if self.width < self.height {
+				return CGSize(width: size.width, height: size.width / aspectRatio)
+			} else {
+				return CGSize(width: size.width * aspectRatio, height: size.height)
+			}
+		case .scaleAspectFit:
+			let aspectRatio = self.width / self.height
+			if self.width < self.height {
+				return CGSize(width: size.width, height: size.width / aspectRatio)
+			} else {
+				return CGSize(width: size.width * aspectRatio, height: size.height)
+			}
+		default:
+			return self
+		}
+	}
+}
+
+extension UIColor {
 	public convenience init(hex: UInt32, alpha: CGFloat = 1) {
 		func byteColor(_ x: UInt32) -> CGFloat {
 			return CGFloat(x & 0xFF) / 255
@@ -42,7 +85,7 @@ public extension UIColor {
 	}
 }
 
-public extension UILabel {
+extension UILabel {
 	///
 	/// Add the monospaced number font descriptor to the current `font`.
 	///
@@ -92,7 +135,7 @@ public extension UILabel {
 	}
 }
 
-public extension UIActivityIndicatorView {
+extension UIActivityIndicatorView {
 	@available(*, deprecated, renamed: "animating")
 	public var fueled_animating: Bool {
 		get {
@@ -117,7 +160,7 @@ public extension UIActivityIndicatorView {
 	}
 }
 
-public extension UITextField {
+extension UITextField {
 	///
 	/// Allows to set the placeholder color by setting the `attributedPlaceholder`.
 	///
@@ -137,7 +180,7 @@ public extension UITextField {
 	}
 }
 
-public extension UIView {
+extension UIView {
 	///
 	/// Adds the given subview into the receiver, and adds constraint so that its top, bottom, left and right's edges are bounds to its superview's edges.
 	///
@@ -224,7 +267,7 @@ public extension UIView {
 	}
 }
 
-public extension UITableView {
+extension UITableView {
 	///
 	/// Deselect given rows, optionally with an animation.
 	///
@@ -261,7 +304,7 @@ public extension UITableView {
 	}
 }
 
-public extension UICollectionView {
+extension UICollectionView {
 	///
 	/// Deselect given items, optionally with an animation.
 	///
@@ -298,7 +341,7 @@ public extension UICollectionView {
 	}
 }
 
-public extension UIImage {
+extension UIImage {
 	///
 	/// Create a `CGContext` allowing to do custom drawing, and returns the resulting image as drawn in the context.
 	/// - Parameters:


### PR DESCRIPTION
Added:
- Add a `TransferState` enum, that can be used to model transfer states such as the progress of a download or an upload.
- Add various utilities, refer to the code for more info & relevant docs

Modified:
- Update some documentation

My goal here is to propose all I think is valuable to add to `FueledUtils`, and if something doesn't agree that something should be in please comment so we can figure out why it can't be and potentially how it could be a part of it.