### PR TITLE
Podspec hotfix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "Carthage/Checkouts/Nimble"]
 	path = Carthage/Checkouts/Nimble
 	url = https://github.com/Quick/Nimble.git
-[submodule "Carthage/Checkouts/Box"]
-	path = Carthage/Checkouts/Box
-	url = https://github.com/robrix/Box.git

--- a/FueledUtils.podspec
+++ b/FueledUtils.podspec
@@ -22,5 +22,6 @@ Pod::Spec.new do |s|
 	s.watchos.exclude_files = ['FueledUtils/FueledUtils.h', 'FueledUtils/ButtonWithTitleAdjustment.swift', 'FueledUtils/DecoratingTextFieldDelegate.swift', 'FueledUtils/DimmingButton.swift', 'FueledUtils/HairlineView.swift', 'FueledUtils/HairlineView.swift', 'FueledUtils/KeyboardInsetHelper.swift', 'FueledUtils/LabelWithTitleAdjustment.swift', 'FueledUtils/ReactiveCocoaExtensions.swift', 'FueledUtils/ScrollViewPage.swift', 'FueledUtils/SetRootViewController.swift', 'FueledUtils/SignalingAlert.swift', 'FueledUtils/UIExtensions.swift', 'FueledUtils/GradientView.swift']
 	s.tvos.exclude_files = ['FueledUtils/FueledUtils.h', 'FueledUtils/KeyboardInsetHelper.swift']
 
-	s.dependency 'ReactiveCocoa', '~> 9.0'
+	s.dependency 'ReactiveSwift', '~> 6.0'
+	s.dependency 'ReactiveCocoa', '~> 10.0'
 end


### PR DESCRIPTION
### Goals :soccer:
This fixes the Podspec which was incorrectly referencing ReactiveCocoa 9.0 instead of `10.0`. The Podspec now mirrors the `Cartfile`.

### Backwards-compatibility:
No breaking changes.
