### PR TITLE
fix(ButtonWithTitleAdjustment): check availability of the `.focused` …

### DIFF
--- a/FueledUtils/ButtonWithTitleAdjustment.swift
+++ b/FueledUtils/ButtonWithTitleAdjustment.swift
@@ -78,7 +78,12 @@ open class ButtonWithTitleAdjustment: UIButton {
 	}
 
 	private func updateAdjustedTitles() {
-		let states: [UIControl.State] = [.normal, .focused, .highlighted, .selected, .disabled, [.selected, .highlighted], [.selected, .disabled]]
+		let states: [UIControl.State]
+		if #available(iOS 9.0, *) {
+			 states = [.normal, .focused, .highlighted, .selected, .disabled, [.selected, .highlighted], [.selected, .disabled]]
+		} else {
+			states = [.normal, .highlighted, .selected, .disabled, [.selected, .highlighted], [.selected, .disabled]]
+		}
 		for state in states {
 			self.setAdjustedTitle(self.title(for: state), for: state)
 		}

--- a/FueledUtils/ReactiveCocoaExtensions.swift
+++ b/FueledUtils/ReactiveCocoaExtensions.swift
@@ -79,7 +79,7 @@ extension Reactive where Base: UIView {
 	///
 	/// Update the `alpha` property of the view with an animation.
 	///
-	var animatedAlpha: BindingTarget<Float> {
+	public var animatedAlpha: BindingTarget<Float> {
 		return self.animatedAlpha()
 	}
 
@@ -89,7 +89,7 @@ extension Reactive where Base: UIView {
 	/// - Parameters:
 	///   - duration: The duration of the animation.
 	///
-	func animatedAlpha(duration: TimeInterval = 0.35) -> BindingTarget<Float> {
+	public func animatedAlpha(duration: TimeInterval = 0.35) -> BindingTarget<Float> {
 		return makeBindingTarget { view, alpha in
 			UIView.animate(withDuration: duration) {
 				view.alpha = CGFloat(alpha)
@@ -102,7 +102,7 @@ extension Reactive where Base: UILabel {
 	///
 	/// Update the `text` property of the label with an animation.
 	///
-	var animatedText: BindingTarget<String> {
+	public var animatedText: BindingTarget<String> {
 		return makeBindingTarget { label, text in
 			label.setText(text, animated: true)
 		}
@@ -110,7 +110,7 @@ extension Reactive where Base: UILabel {
 	///
 	/// Update the `attributedText` property of the label with an animation.
 	///
-	var animatedAttributedText: BindingTarget<NSAttributedString> {
+	public var animatedAttributedText: BindingTarget<NSAttributedString> {
 		return makeBindingTarget { label, text in
 			label.setAttributedText(text, animated: true)
 		}


### PR DESCRIPTION
### Goals :soccer:
Add iOS version check in order to be able to use `.focused` state which is only available starting from iOS 9. 
@stephanecopin, @leontiy please consider another solution: bump `ios.deployment_target` in the podspec from 8 to 11 because the current xcode projects has iOS Deployment Target set as `11` (that's why such issues can't be found while compiling the project at this moment.)

### Backwards-compatibility:
No breaking changes.