### PR TITLE
Misc updates

### DIFF
--- a/FueledUtils/Combine/Action.swift
+++ b/FueledUtils/Combine/Action.swift
@@ -97,12 +97,13 @@ public final class Action<Input, Output, Failure: Swift.Error> {
 				.eraseToAnyPublisher()
 		}
 
-		self~\.isEnabled <~ Publishers.CombineLatest(
+		Publishers.CombineLatest(
 			isEnabled,
 			self.$isExecuting
 		)
-		.map { $0 && !$1 }
-		>>> self.cancellables
+			.map { $0 && !$1 }
+			.assign(to: \.isEnabled, withoutRetaining: self)
+			.store(in: &self.cancellables)
 	}
 
 	public func apply(_ input: Input) -> AnyPublisher<Output, ActionError<Failure>> {

--- a/FueledUtils/Combine/ObservableObjectExtensions.swift
+++ b/FueledUtils/Combine/ObservableObjectExtensions.swift
@@ -65,7 +65,7 @@ extension ObservableObject where Self.ObjectWillChangePublisher == ObservableObj
 					cancellables = Set()
 					objects.forEach { object in
 						object.objectWillChange.sink { [weak self] _ in self?.objectWillChange.send() }
-							>>> cancellables
+							.store(in: &cancellables)
 					}
 					return .unlimited
 				}

--- a/FueledUtils/SwiftUI/FramePreferenceKey.swift
+++ b/FueledUtils/SwiftUI/FramePreferenceKey.swift
@@ -14,8 +14,14 @@
 
 import SwiftUI
 
-public struct FramePreferenceKey: PreferenceKey {
-	public static var defaultValue: CGRect = .zero
+///
+/// Used to retrieve the frame of a view through a preference key.
+/// `TagType` is used to uniquely identify the view using the preference key.
+///
+public struct FramePreferenceKey<TagType>: PreferenceKey {
+	public static var defaultValue: CGRect {
+		.zero
+	}
 
 	public static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
 		value = nextValue()


### PR DESCRIPTION
### Issue Link :link:
Fix Combine podspec that was using `CombineOperators` when it shouldn't have.
This also update `FramePreferenceKey` with generics, so the type using it can be specified explicitely.

### Backwards-compatibility:

`FramePreferenceKey` interface changed.

