### PR TITLE
Fix segfault when using `backgroundBlur` when compiling with optimizations enabled

### DIFF
--- a/FueledUtils/SwiftUI/BackgroundBlur.swift
+++ b/FueledUtils/SwiftUI/BackgroundBlur.swift
@@ -32,6 +32,7 @@ extension View {
 			color
 			BlurView(style: style)
 			self
+				.eraseToAnyView()
 		}
 	}
 }

--- a/FueledUtils/SwiftUI/BlurView.swift
+++ b/FueledUtils/SwiftUI/BlurView.swift
@@ -14,13 +14,14 @@
 
 import SwiftUI
 
-extension View {
-	public func backgroundBlur(style: UIBlurEffect.Style, color: Color? = nil) -> some View {
-		ZStack {
-			color
-			BlurView(style: style)
-			self
-				.eraseToAnyView()
-		}
+public struct BlurView: UIViewRepresentable {
+	public let style: UIBlurEffect.Style
+
+	public func makeUIView(context: Context) -> UIVisualEffectView {
+		UIVisualEffectView(effect: UIBlurEffect(style: self.style))
+	}
+
+	public func updateUIView(_ visualEffectView: UIVisualEffectView, context: Context) {
+		visualEffectView.effect = UIBlurEffect(style: self.style)
 	}
 }


### PR DESCRIPTION
### Goals :soccer:
Fix segfault when using `backgroundBlur` when compiling with optimizations enabled.

### Backwards-compatibility:
No interface changes.
