### PR TITLE
Add some unit tests for non-UI related helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 
 ##### Bug Fixes
 
+- Fix a bug in `CombineLatestMany` where cancelling the resulting publisher would not cancel the array of publishers themselves.
+  [Stéphane Copin](https://github.com/stephanecopin)
+  [#55](https://github.com/Fueled/ios-utilities/pull/55)
+
 - Fix a bug in `Action` where a cancellation would be ignored and not set `isExecuting` to `false`
   [Stéphane Copin](https://github.com/stephanecopin)
   [#54](https://github.com/Fueled/ios-utilities/pull/54)

--- a/FueledUtils/Core/Atomic.swift
+++ b/FueledUtils/Core/Atomic.swift
@@ -61,11 +61,20 @@ public struct Atomic<Value> {
 		self.atomicValue.value
 	}
 
-	public mutating func modify(_ modify: (inout Value) -> Void) {
+	public var projectedValue: Atomic {
+		get {
+			self
+		}
+		set {
+			self = newValue
+		}
+	}
+
+	public mutating func modify<Return>(_ modify: (inout Value) -> Return) -> Return {
 		self.atomicValue.modify(modify)
 	}
 
-	public mutating func withValue(_ getter: (Value) -> Void) {
+	public mutating func withValue<Return>(_ getter: (Value) -> Return) -> Return {
 		self.atomicValue.withValue(getter)
 	}
 

--- a/Tests/FueledUtils.xcodeproj/project.pbxproj
+++ b/Tests/FueledUtils.xcodeproj/project.pbxproj
@@ -8,12 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		EE9B3A498587AC2D3461D310 /* Pods_Common_FueledUtilsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F46CDEA885028D8DB189B3CB /* Pods_Common_FueledUtilsTests.framework */; };
-		F429742A25378348004BFA85 /* ReactiveOverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */; };
-		F429742E25378425004BFA85 /* OverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742D25378425004BFA85 /* OverridingActionSpec.swift */; };
-		F463C73C241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */; };
-		F463C73D241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */; };
-		F46D2DA6252E4E4A00B6987A /* OrderedSetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46D2DA5252E4E4A00B6987A /* OrderedSetSpec.swift */; };
-		F49963202537459200E2D4B5 /* CoalescingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F499631F2537459200E2D4B5 /* CoalescingActionSpec.swift */; };
+		F453AA7B2538DE55008F045B /* CombineLatestManySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F453AA7A2538DE55008F045B /* CombineLatestManySpec.swift */; };
+		F453AA7F2538E05E008F045B /* ReactiveSwiftExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */; };
+		F453AA802538E05E008F045B /* OrderedSetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46D2DA5252E4E4A00B6987A /* OrderedSetSpec.swift */; };
+		F453AA812538E05E008F045B /* CoalescingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F499631F2537459200E2D4B5 /* CoalescingActionSpec.swift */; };
+		F453AA822538E05E008F045B /* OverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742D25378425004BFA85 /* OverridingActionSpec.swift */; };
+		F453AA832538E05E008F045B /* ReactiveCoalescingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */; };
+		F453AA842538E05E008F045B /* ReactiveOverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,6 +30,7 @@
 		E7AC5BA00D7F6054AC66E468 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveOverridingActionSpec.swift; sourceTree = "<group>"; };
 		F429742D25378425004BFA85 /* OverridingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridingActionSpec.swift; sourceTree = "<group>"; };
+		F453AA7A2538DE55008F045B /* CombineLatestManySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestManySpec.swift; sourceTree = "<group>"; };
 		F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveCoalescingActionSpec.swift; sourceTree = "<group>"; };
 		F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveSwiftExtensionsSpec.swift; sourceTree = "<group>"; };
 		F463C73F241835EA000A0B29 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */,
 				F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */,
 				F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */,
+				F453AA7A2538DE55008F045B /* CombineLatestManySpec.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -245,12 +248,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F46D2DA6252E4E4A00B6987A /* OrderedSetSpec.swift in Sources */,
-				F429742A25378348004BFA85 /* ReactiveOverridingActionSpec.swift in Sources */,
-				F463C73C241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift in Sources */,
-				F49963202537459200E2D4B5 /* CoalescingActionSpec.swift in Sources */,
-				F463C73D241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift in Sources */,
-				F429742E25378425004BFA85 /* OverridingActionSpec.swift in Sources */,
+				F453AA7B2538DE55008F045B /* CombineLatestManySpec.swift in Sources */,
+				F453AA802538E05E008F045B /* OrderedSetSpec.swift in Sources */,
+				F453AA822538E05E008F045B /* OverridingActionSpec.swift in Sources */,
+				F453AA832538E05E008F045B /* ReactiveCoalescingActionSpec.swift in Sources */,
+				F453AA812538E05E008F045B /* CoalescingActionSpec.swift in Sources */,
+				F453AA7F2538E05E008F045B /* ReactiveSwiftExtensionsSpec.swift in Sources */,
+				F453AA842538E05E008F045B /* ReactiveOverridingActionSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/FueledUtils.xcodeproj/project.pbxproj
+++ b/Tests/FueledUtils.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		F453AA822538E05E008F045B /* OverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742D25378425004BFA85 /* OverridingActionSpec.swift */; };
 		F453AA832538E05E008F045B /* ReactiveCoalescingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */; };
 		F453AA842538E05E008F045B /* ReactiveOverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */; };
+		F453AA892538EF16008F045B /* SinkForLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F453AA882538EF16008F045B /* SinkForLifetimeSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveOverridingActionSpec.swift; sourceTree = "<group>"; };
 		F429742D25378425004BFA85 /* OverridingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridingActionSpec.swift; sourceTree = "<group>"; };
 		F453AA7A2538DE55008F045B /* CombineLatestManySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestManySpec.swift; sourceTree = "<group>"; };
+		F453AA882538EF16008F045B /* SinkForLifetimeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinkForLifetimeSpec.swift; sourceTree = "<group>"; };
 		F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveCoalescingActionSpec.swift; sourceTree = "<group>"; };
 		F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveSwiftExtensionsSpec.swift; sourceTree = "<group>"; };
 		F463C73F241835EA000A0B29 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 				F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */,
 				F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */,
 				F453AA7A2538DE55008F045B /* CombineLatestManySpec.swift */,
+				F453AA882538EF16008F045B /* SinkForLifetimeSpec.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -250,6 +253,7 @@
 			files = (
 				F453AA7B2538DE55008F045B /* CombineLatestManySpec.swift in Sources */,
 				F453AA802538E05E008F045B /* OrderedSetSpec.swift in Sources */,
+				F453AA892538EF16008F045B /* SinkForLifetimeSpec.swift in Sources */,
 				F453AA822538E05E008F045B /* OverridingActionSpec.swift in Sources */,
 				F453AA832538E05E008F045B /* ReactiveCoalescingActionSpec.swift in Sources */,
 				F453AA812538E05E008F045B /* CoalescingActionSpec.swift in Sources */,

--- a/Tests/FueledUtils.xcodeproj/project.pbxproj
+++ b/Tests/FueledUtils.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		EE9B3A498587AC2D3461D310 /* Pods_Common_FueledUtilsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F46CDEA885028D8DB189B3CB /* Pods_Common_FueledUtilsTests.framework */; };
+		F429742A25378348004BFA85 /* ReactiveOverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */; };
+		F429742E25378425004BFA85 /* OverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742D25378425004BFA85 /* OverridingActionSpec.swift */; };
 		F463C73C241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */; };
 		F463C73D241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */; };
 		F46D2DA6252E4E4A00B6987A /* OrderedSetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46D2DA5252E4E4A00B6987A /* OrderedSetSpec.swift */; };
@@ -25,6 +27,8 @@
 		D43FD9799A872E88963939C1 /* Pods-Common-FueledUtilsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-FueledUtilsTests.debug.xcconfig"; path = "Target Support Files/Pods-Common-FueledUtilsTests/Pods-Common-FueledUtilsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D498AEE5BC8A0A514416E6DA /* Pods-Common-FueledUtilsTests-ReactiveSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-FueledUtilsTests-ReactiveSwift.debug.xcconfig"; path = "Target Support Files/Pods-Common-FueledUtilsTests-ReactiveSwift/Pods-Common-FueledUtilsTests-ReactiveSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		E7AC5BA00D7F6054AC66E468 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveOverridingActionSpec.swift; sourceTree = "<group>"; };
+		F429742D25378425004BFA85 /* OverridingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridingActionSpec.swift; sourceTree = "<group>"; };
 		F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveCoalescingActionSpec.swift; sourceTree = "<group>"; };
 		F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveSwiftExtensionsSpec.swift; sourceTree = "<group>"; };
 		F463C73F241835EA000A0B29 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -102,9 +106,11 @@
 			isa = PBXGroup;
 			children = (
 				F499631F2537459200E2D4B5 /* CoalescingActionSpec.swift */,
+				F46D2DA5252E4E4A00B6987A /* OrderedSetSpec.swift */,
+				F429742D25378425004BFA85 /* OverridingActionSpec.swift */,
 				F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */,
 				F463C73B241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift */,
-				F46D2DA5252E4E4A00B6987A /* OrderedSetSpec.swift */,
+				F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -240,9 +246,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				F46D2DA6252E4E4A00B6987A /* OrderedSetSpec.swift in Sources */,
+				F429742A25378348004BFA85 /* ReactiveOverridingActionSpec.swift in Sources */,
 				F463C73C241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift in Sources */,
 				F49963202537459200E2D4B5 /* CoalescingActionSpec.swift in Sources */,
 				F463C73D241835DD000A0B29 /* ReactiveSwiftExtensionsSpec.swift in Sources */,
+				F429742E25378425004BFA85 /* OverridingActionSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Tests/CombineLatestManySpec.swift
+++ b/Tests/Tests/CombineLatestManySpec.swift
@@ -1,0 +1,192 @@
+// Copyright © 2020 Fueled Digital Media, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Combine
+import FueledUtils
+import Quick
+import Nimble
+
+class CombineLatestManySpec: QuickSpec {
+	private var cancellables: [AnyCancellable]!
+
+	override func spec() {
+		describe("Publishers.CombineLatestMany") {
+			beforeEach {
+				self.cancellables = []
+			}
+			describe("with zero elements") {
+				it("should complete instantaneously with an empty array and no errors") {
+					var completionCount = 0
+					var valueCount = 0
+					Publishers.CombineLatestMany<[Just<Void>]>([]).sink(
+						receiveCompletion: { completion in
+							let isFinished: Bool
+							switch completion {
+							case .failure:
+								isFinished = false
+							case .finished:
+								isFinished = true
+							}
+							expect(isFinished) == true
+							completionCount += 1
+						},
+						receiveValue: { values in
+							expect(values).to(haveCount(0))
+							valueCount += 1
+						}
+					)
+						.store(in: &self.cancellables)
+
+					expect(completionCount) == 1
+					expect(valueCount) == 1
+				}
+			}
+			describe("with two elements") {
+				it("should match the native CombineLatest behavior") {
+					var completionCount = 0
+					var valueCount = 0
+					var nativeValues: [Int] = []
+					var manyValues: [Int] = []
+
+					func publisher(_ value: Int) -> AnyPublisher<Int, Never> {
+						Just(value).delay(for: 0.3, scheduler: DispatchQueue.main)
+							.eraseToAnyPublisher()
+					}
+
+					Publishers.CombineLatest(
+						publisher(1).append(publisher(3)),
+						publisher(2)
+					)
+						.sink(
+							receiveCompletion: { completion in
+								let isFinished: Bool
+								switch completion {
+								case .failure:
+									isFinished = false
+								case .finished:
+									isFinished = true
+								}
+								expect(isFinished) == true
+								completionCount += 1
+							},
+							receiveValue: { value1, value2 in
+								nativeValues = [value1, value2]
+								valueCount += 1
+							}
+						)
+						.store(in: &self.cancellables)
+
+					Publishers.CombineLatestMany(
+						[
+							publisher(1).append(publisher(3)).eraseToAnyPublisher(),
+							publisher(2).eraseToAnyPublisher()
+						]
+					)
+						.sink(
+							receiveCompletion: { completion in
+								let isFinished: Bool
+								switch completion {
+								case .failure:
+									isFinished = false
+								case .finished:
+									isFinished = true
+								}
+								expect(isFinished) == true
+								completionCount += 1
+							},
+							receiveValue: { values in
+								manyValues = values
+								valueCount += 1
+							}
+						)
+						.store(in: &self.cancellables)
+
+					expect(completionCount).toEventually(equal(2))
+					expect(valueCount).toEventually(equal(4))
+
+					expect(nativeValues).toEventually(equal([3, 2]))
+					expect(manyValues).toEventually(equal([3, 2]))
+				}
+			}
+			describe("with two publishers") {
+				it("should correctly interrupt the publishers when interrupted") {
+					var subscriptionCount = 0
+					var cancelCount = 0
+					var nativeValueCount = 0
+					var nativeValues: [Int] = []
+					var manyValueCount = 0
+					var manyValues: [Int] = []
+
+					func publisher(_ value: Int) -> AnyPublisher<Int, Never> {
+						Just(1).delay(for: 0.5, scheduler: DispatchQueue.main)
+							.handleEvents(
+								receiveSubscription: { _ in
+									subscriptionCount += 1
+								},
+								receiveCancel: {
+									cancelCount += 1
+								}
+							)
+							.eraseToAnyPublisher()
+					}
+
+					var cancellable = Publishers.CombineLatest(
+						publisher(1),
+						publisher(2)
+					)
+						.handleEvents(
+							receiveCancel: {
+								cancelCount += 1
+							}
+						)
+						.sink(
+							receiveValue: { value1, value2 in
+								nativeValues = [value1, value2]
+								nativeValueCount += 1
+							}
+						)
+
+					cancellable = Publishers.CombineLatestMany(
+						[
+							publisher(1),
+							publisher(2)
+						]
+					)
+						.handleEvents(
+							receiveCancel: {
+								cancelCount += 1
+							}
+						)
+						.sink(
+							receiveValue: { values in
+								manyValues = values
+								manyValueCount += 1
+							}
+						)
+
+					cancellable.cancel()
+
+					expect(subscriptionCount) == 4
+					expect(cancelCount).toEventually(equal(6))
+
+					expect(nativeValueCount).toEventually(equal(0))
+					expect(nativeValues).toEventually(haveCount(0))
+
+					expect(manyValueCount).toEventually(equal(0))
+					expect(manyValues).toEventually(haveCount(0))
+				}
+			}
+		}
+	}
+}

--- a/Tests/Tests/ReactiveOverridingActionSpec.swift
+++ b/Tests/Tests/ReactiveOverridingActionSpec.swift
@@ -1,0 +1,62 @@
+// Copyright © 2020 Fueled Digital Media, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Quick
+import FueledUtils
+import Nimble
+import ReactiveSwift
+
+class ReactiveOverridingActionSpec: QuickSpec {
+	override func spec() {
+		describe("ReactiveOverridingAction") {
+			describe("apply.start()") {
+				it("should cancel the previous work") {
+					var startCounter = 0
+					var disposeCounter = 0
+					var interruptedCounter = 0
+					let overridingAction = ReactiveOverridingAction {
+						SignalProducer(value: 2.0)
+							.observe(on: UIScheduler())
+							.delay(1.0, on: QueueScheduler.main)
+							.on(
+								started: {
+									startCounter += 1
+								},
+								interrupted: {
+									interruptedCounter += 1
+								},
+								disposed: {
+									disposeCounter += 1
+								}
+							)
+					}
+
+					expect(startCounter) == 0
+
+					let producersCount = 5
+					(0..<producersCount).forEach { _ in
+						overridingAction.apply(()).start()
+					}
+
+					expect(startCounter) == producersCount
+					expect(disposeCounter).toEventually(equal(producersCount - 1), timeout: 0.01)
+					expect(interruptedCounter).toEventually(equal(producersCount - 1), timeout: 0.01)
+
+					expect(disposeCounter).toEventually(equal(producersCount), timeout: 2.0)
+					expect(interruptedCounter).toEventually(equal(producersCount - 1), timeout: 2.0)
+				}
+			}
+		}
+	}
+}

--- a/Tests/Tests/SinkForLifetimeSpec.swift
+++ b/Tests/Tests/SinkForLifetimeSpec.swift
@@ -1,0 +1,51 @@
+// Copyright © 2020 Fueled Digital Media, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Quick
+import Nimble
+import FueledUtils
+import ReactiveSwift
+import Combine
+
+class SinkForLifetimeSpec: QuickSpec {
+	override func spec() {
+		describe("sinkForLifeTimeOf()") {
+			it("should cancel itself automatically when the object becomes out of scope") {
+				var object: NSObject!
+				var valueCount = 0
+				var cancelCount = 0
+				do {
+					object = NSObject()
+					Timer.publish(every: 0.42, on: .current, in: .common)
+						.autoconnect()
+						.handleEvents(
+							receiveCancel: {
+								cancelCount += 1
+							}
+						)
+						.sinkForLifetimeOf(object) { _ in
+							valueCount += 1
+						}
+				}
+
+				DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+					object = nil
+				}
+
+				expect(valueCount).toEventually(equal(2))
+				expect(cancelCount).toEventually(equal(1), timeout: 2.0)
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Tests :mag:

This PR adds unit tests for `OverridingAction`, `CoalescingAction`, `ReactiveOverridingAction` & `CombineLatestMany`.

The unit tests further pointed out an issue in `CombineLatestMany (where the `Publisher`s wouldn't be cancelled at all), which this PR also fix.

Depends on #54 