### PR TITLE
Add `confirmAction` parameter to `tapAction` allowing to optionally add a confirm action to a button action

### DIFF
--- a/FueledUtils/Combine/ActionProtocol.swift
+++ b/FueledUtils/Combine/ActionProtocol.swift
@@ -101,7 +101,7 @@ extension ActionProtocol where Input == Void {
 	///   or returns an appropriate `ApplyError` indicating the specific error
 	///   that happened.
 	///
-	func apply() -> ApplyPublisher {
+	public func apply() -> ApplyPublisher {
 		return self.apply(())
 	}
 }


### PR DESCRIPTION
### Goals :soccer:
Add `confirmAction` parameter to `tapAction` allowing to optionally add a confirm action to a button action.