### PR TITLE
Fix termination that could be sent twice

### DIFF
--- a/FueledUtils/Combine/Publisher+AdditionalHandleEvents.swift
+++ b/FueledUtils/Combine/Publisher+AdditionalHandleEvents.swift
@@ -71,7 +71,17 @@ extension Publisher {
 		receiveResult: ((Result<Output, Failure>) -> Void)?,
 		receiveRequest: ((Subscribers.Demand) -> Void)? = nil
 	) -> Publishers.HandleEvents<Self> {
-		self.handleEvents(
+		var hasTerminated = false
+		let receiveTermination = receiveTermination.map { receiveTermination in
+			{
+				if hasTerminated {
+					return
+				}
+				hasTerminated = true
+				receiveTermination()
+			}
+		}
+		return self.handleEvents(
 			receiveSubscription: receiveSubscription,
 			receiveOutput: {
 				receiveOutput?($0)


### PR DESCRIPTION
### Goals :soccer:
Fix `receiveTermination` that could be sent twice, if the producer is cancelled after completing.
