### PR TITLE
[SwiftPM] Add Swift Package Manager Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ xcuserdata/
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ Pods/
 
 Carthage/Build
 
+# SwiftPM
+.swiftpm/
+
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Master
 
 ##### New Features/Enhancements
+- Add Swift Package Manager Support
+  [notbenoit](https://github.com/notbenoit)
+  [#71](https://github.com/Fueled/ios-utilities/pulls/71)
 
 - Add `ActionProtocol`
 - Add `AnyAction`, allowing to type-erase any actions represented by a `ActionProtocol`

--- a/FueledUtils/Combine/Action.swift
+++ b/FueledUtils/Combine/Action.swift
@@ -14,6 +14,10 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+#endif
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public final class Action<Input, Output, Failure: Swift.Error> {

--- a/FueledUtils/Combine/ActionError.swift
+++ b/FueledUtils/Combine/ActionError.swift
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsReactiveCommon
+#endif
+
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum ActionError<Error: Swift.Error>: Swift.Error {
 	case disabled

--- a/FueledUtils/Combine/AnyCurrentValuePublisher.swift
+++ b/FueledUtils/Combine/AnyCurrentValuePublisher.swift
@@ -14,6 +14,9 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsReactiveCommon
+#endif
 
 ///
 /// A type-erasing current value publisher.
@@ -35,7 +38,7 @@ public struct AnyCurrentValuePublisher<Output, Failure: Swift.Error>: CurrentVal
 		self.receiveSubcriberClosure = { _ = $0.receive(value) }
 	}
 
-	public init<CurrentValuePublisher: FueledUtils.CurrentValuePublisher>(_ publisher: CurrentValuePublisher) where CurrentValuePublisher.Output == Output, CurrentValuePublisher.Failure == Failure {
+	public init<Publisher: CurrentValuePublisher>(_ publisher: Publisher) where Publisher.Output == Output, Publisher.Failure == Failure {
 		self.valueGetter = { publisher.value }
 		self.receiveSubcriberClosure = { publisher.receive(subscriber: $0) }
 	}

--- a/FueledUtils/Combine/CoalescingAction.swift
+++ b/FueledUtils/Combine/CoalescingAction.swift
@@ -14,6 +14,10 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+#endif
 
 ///
 /// Similar to `Action`, except if the action is already executing, subsequent `apply()` call will not fail,

--- a/FueledUtils/Combine/CombineExtensions+Cancellables.swift
+++ b/FueledUtils/Combine/CombineExtensions+Cancellables.swift
@@ -14,6 +14,11 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsReactiveCommon)
+import Foundation
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+#endif
 
 private var cancellablesKey: UInt8 = 0
 

--- a/FueledUtils/Combine/ObservableObjectExtensions.swift
+++ b/FueledUtils/Combine/ObservableObjectExtensions.swift
@@ -14,6 +14,11 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsReactiveCommon)
+import Foundation
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+#endif
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension ObservableObject where Self.ObjectWillChangePublisher == ObservableObjectPublisher {

--- a/FueledUtils/Combine/Publisher+TransferState.swift
+++ b/FueledUtils/Combine/Publisher+TransferState.swift
@@ -14,6 +14,10 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+#endif
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension Publisher where Output: TransferStateProtocol {

--- a/FueledUtils/Combine/PublisherExtensions.swift
+++ b/FueledUtils/Combine/PublisherExtensions.swift
@@ -14,6 +14,10 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+#endif
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension Publisher {

--- a/FueledUtils/Combine/PublishersExtensions.swift
+++ b/FueledUtils/Combine/PublishersExtensions.swift
@@ -14,6 +14,10 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+#endif
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension Publishers {

--- a/FueledUtils/CombineOperators/Combine+Operators.swift
+++ b/FueledUtils/CombineOperators/Combine+Operators.swift
@@ -14,6 +14,12 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsCombine)
+import FueledUtilsCombine
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+public typealias OptionalProtocol = FueledUtilsCore.OptionalProtocol
+#endif
 
 // swiftlint:disable generic_type_name
 

--- a/FueledUtils/ReactiveSwift/ActionError+ActionErrorProtocol.swift
+++ b/FueledUtils/ReactiveSwift/ActionError+ActionErrorProtocol.swift
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsReactiveCommon
+#endif
 import ReactiveSwift
 
 extension ReactiveSwift.ActionError: ActionErrorProtocol {

--- a/FueledUtils/ReactiveSwift/ReactiveCoalescingAction.swift
+++ b/FueledUtils/ReactiveSwift/ReactiveCoalescingAction.swift
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FueledUtilsCore)
+import FueledUtilsCore
+#endif
 import ReactiveSwift
 
 ///

--- a/FueledUtils/ReactiveSwift/ReactiveCocoaExtensions.swift
+++ b/FueledUtils/ReactiveSwift/ReactiveCocoaExtensions.swift
@@ -13,11 +13,16 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FueledUtilsReactiveCommon)
+import FueledUtilsCore
+import FueledUtilsReactiveCommon
+#endif
 import ReactiveCocoa
 import ReactiveSwift
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
+import AppKit
 #endif
 
 ///

--- a/FueledUtils/ReactiveSwift/ReactiveCocoaExtensions.swift
+++ b/FueledUtils/ReactiveSwift/ReactiveCocoaExtensions.swift
@@ -19,7 +19,7 @@ import FueledUtilsReactiveCommon
 #endif
 import ReactiveCocoa
 import ReactiveSwift
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 #elseif canImport(AppKit)
 import AppKit

--- a/FueledUtils/ReactiveSwift/TransferState+Reactive.swift
+++ b/FueledUtils/ReactiveSwift/TransferState+Reactive.swift
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FueledUtilsCore)
+import FueledUtilsCore
+#endif
 import ReactiveSwift
 
 extension SignalProtocol {

--- a/FueledUtils/ReactiveSwiftUIKit/SignalingAlert.swift
+++ b/FueledUtils/ReactiveSwiftUIKit/SignalingAlert.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import Foundation
 import ReactiveCocoa
 import ReactiveSwift
@@ -107,3 +108,4 @@ public final class SignalingAlert<T> {
 		}
 	}
 }
+#endif

--- a/FueledUtils/ReactiveSwiftUIKit/SignalingAlert.swift
+++ b/FueledUtils/ReactiveSwiftUIKit/SignalingAlert.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import Foundation
 import ReactiveCocoa
 import ReactiveSwift

--- a/FueledUtils/ReactiveSwiftUIKit/UIReactiveExtensions.swift
+++ b/FueledUtils/ReactiveSwiftUIKit/UIReactiveExtensions.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import Foundation
 import ReactiveSwift
 import UIKit
@@ -34,3 +35,4 @@ extension Reactive where Base: UILabel {
 		}
 	}
 }
+#endif

--- a/FueledUtils/UIKit/ButtonWithTitleAdjustment.swift
+++ b/FueledUtils/UIKit/ButtonWithTitleAdjustment.swift
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 ///

--- a/FueledUtils/UIKit/ButtonWithTitleAdjustment.swift
+++ b/FueledUtils/UIKit/ButtonWithTitleAdjustment.swift
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#if canImport(UIKit)
 import UIKit
 
 ///
@@ -108,3 +108,4 @@ open class ButtonWithTitleAdjustment: UIButton {
 		self.setAttributedTitle(adjustedString, for: state)
 	}
 }
+#endif

--- a/FueledUtils/UIKit/DecoratingTextFieldDelegate.swift
+++ b/FueledUtils/UIKit/DecoratingTextFieldDelegate.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 import Foundation
 

--- a/FueledUtils/UIKit/DecoratingTextFieldDelegate.swift
+++ b/FueledUtils/UIKit/DecoratingTextFieldDelegate.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import UIKit
 import Foundation
 
@@ -192,3 +193,4 @@ extension DecoratingTextFieldDelegate: UITextFieldDelegate {
 		return false
 	}
 }
+#endif

--- a/FueledUtils/UIKit/DimmingButton.swift
+++ b/FueledUtils/UIKit/DimmingButton.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import Foundation
 import UIKit
 

--- a/FueledUtils/UIKit/DimmingButton.swift
+++ b/FueledUtils/UIKit/DimmingButton.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
@@ -58,3 +59,4 @@ public final class DimmingButton: UIButton {
 		(view ?? self).alpha = dimmedAlpha
 	}
 }
+#endif

--- a/FueledUtils/UIKit/GradientView.swift
+++ b/FueledUtils/UIKit/GradientView.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 ///

--- a/FueledUtils/UIKit/GradientView.swift
+++ b/FueledUtils/UIKit/GradientView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import UIKit
 
 ///
@@ -274,3 +275,4 @@ extension CGPoint {
 		return CGPoint(x: 1.0, y: 0.0)
 	}
 }
+#endif

--- a/FueledUtils/UIKit/HairlineView.swift
+++ b/FueledUtils/UIKit/HairlineView.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import Foundation
 import UIKit
 

--- a/FueledUtils/UIKit/HairlineView.swift
+++ b/FueledUtils/UIKit/HairlineView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
@@ -42,3 +43,4 @@ open class HairlineView: UIView {
 		}
 	}
 }
+#endif

--- a/FueledUtils/UIKit/KeyboardInsetHelper.swift
+++ b/FueledUtils/UIKit/KeyboardInsetHelper.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
@@ -104,3 +105,4 @@ open class KeyboardInsetHelper: NSObject {
 		referenceView?.layoutIfNeeded()
 	}
 }
+#endif

--- a/FueledUtils/UIKit/KeyboardInsetHelper.swift
+++ b/FueledUtils/UIKit/KeyboardInsetHelper.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS) && !os(tvOS)
 import Foundation
 import UIKit
 

--- a/FueledUtils/UIKit/LabelWithTitleAdjustment.swift
+++ b/FueledUtils/UIKit/LabelWithTitleAdjustment.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import UIKit
 import Foundation
 
@@ -111,3 +112,4 @@ open class LabelWithTitleAdjustment: UILabel {
 		self.setAdjustedAttributedText(text.map { NSAttributedString(string: $0) })
 	}
 }
+#endif

--- a/FueledUtils/UIKit/LabelWithTitleAdjustment.swift
+++ b/FueledUtils/UIKit/LabelWithTitleAdjustment.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 import Foundation
 

--- a/FueledUtils/UIKit/ScrollViewPage.swift
+++ b/FueledUtils/UIKit/ScrollViewPage.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import UIKit
 
 extension UIScrollView {
@@ -83,3 +84,4 @@ extension UIScrollView {
 		self.setContentOffset(offset, animated: animated)
 	}
 }
+#endif

--- a/FueledUtils/UIKit/ScrollViewPage.swift
+++ b/FueledUtils/UIKit/ScrollViewPage.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 extension UIScrollView {

--- a/FueledUtils/UIKit/SetRootViewController.swift
+++ b/FueledUtils/UIKit/SetRootViewController.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
@@ -51,3 +52,4 @@ extension UIApplicationDelegate {
 		}
 	}
 }
+#endif

--- a/FueledUtils/UIKit/SetRootViewController.swift
+++ b/FueledUtils/UIKit/SetRootViewController.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import Foundation
 import UIKit
 

--- a/FueledUtils/UIKit/UIExtensions.swift
+++ b/FueledUtils/UIKit/UIExtensions.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
@@ -663,3 +664,4 @@ extension UIImage {
 		return image.resizableImage(withCapInsets: .init(top: capInset, left: capInset, bottom: capInset, right: capInset), resizingMode: .stretch)
 	}
 }
+#endif

--- a/FueledUtils/UIKit/UIExtensions.swift
+++ b/FueledUtils/UIKit/UIExtensions.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import Foundation
 import UIKit
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,42 @@
   "object": {
     "pins": [
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
+          "version": "4.0.0"
+        }
+      },
+      {
         "package": "ReactiveCocoa",
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveCocoa.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "ReactiveCocoa",
+        "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveCocoa.git",
+        "state": {
+          "branch": null,
+          "revision": "8a5b07b18c6abb8e12fb845bf742675dc4914ed8",
+          "version": "12.0.0"
+        }
+      },
+      {
+        "package": "ReactiveSwift",
+        "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "efb2f0a6f6c8739cce8fb14148a5bd3c83f2f91d",
+          "version": "7.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,9 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.0.0"),
-		.package(url: "https://github.com/ReactiveCocoa/ReactiveCocoa.git", from: "12.0.0")
+		.package(url: "https://github.com/ReactiveCocoa/ReactiveCocoa.git", from: "12.0.0"),
+		.package(url: "https://github.com/Quick/Quick.git", from: "4.0.0"),
+		.package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
 	],
 	targets: [
 		.target(
@@ -103,6 +105,16 @@ let package = Package(
 			name: "FueledUtilsReactiveCombineBridge",
 			dependencies: ["FueledUtilsCombine", "FueledUtilsReactiveSwift"],
 			path: "FueledUtils/ReactiveCombineBridge"
+		),
+		.testTarget(
+				name: "FueledUtils",
+				dependencies: [
+					"FueledUtilsCombineUIKit",
+					"FueledUtilsReactiveSwiftUIKit",
+					"Quick",
+					"Nimble",
+				],
+				path: "Tests/Tests"
 		),
 	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,108 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+	name: "FueledUtils",
+	platforms: [
+		.macOS(.v10_12), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
+	],
+	products: [
+		.library(
+			name: "FueledUtilsCore",
+			targets: ["FueledUtilsCore"]
+		),
+		.library(
+			name: "FueledUtilsReactiveCommon",
+			targets: ["FueledUtilsReactiveCommon"]
+		),
+		.library(
+			name: "FueledUtilsReactiveSwift",
+			targets: ["FueledUtilsReactiveSwift"]
+		),
+		.library(
+			name: "FueledUtilsUIKit",
+			targets: ["FueledUtilsUIKit"]
+		),
+		.library(
+			name: "FueledUtilsReactiveSwiftUIKit",
+			targets: ["FueledUtilsReactiveSwiftUIKit"]
+		),
+		.library(
+			name: "FueledUtilsCombine",
+			targets: ["FueledUtilsCombine"]
+		),
+		.library(
+			name: "FueledUtilsCombineOperators",
+			targets: ["FueledUtilsCombineOperators"]
+		),
+		.library(
+			name: "FueledUtilsCombineUIKit",
+			targets: ["FueledUtilsCombineUIKit"]
+		),
+		.library(
+			name: "FueledUtilsSwiftUI",
+			targets: ["FueledUtilsSwiftUI"]
+		),
+		.library(
+			name: "FueledUtilsReactiveCombineBridge",
+			targets: ["FueledUtilsReactiveCombineBridge"]
+		),
+	],
+	dependencies: [
+		.package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.0.0"),
+		.package(url: "https://github.com/ReactiveCocoa/ReactiveCocoa.git", from: "12.0.0")
+	],
+	targets: [
+		.target(
+			name: "FueledUtilsCore",
+			path: "FueledUtils/Core"
+		),
+		.target(
+			name: "FueledUtilsReactiveCommon",
+			dependencies: ["FueledUtilsCore"],
+			path: "FueledUtils/ReactiveCommon"
+		),
+		.target(
+			name: "FueledUtilsReactiveSwift",
+			dependencies: ["FueledUtilsReactiveCommon", "ReactiveSwift", "ReactiveCocoa"],
+			path: "FueledUtils/ReactiveSwift"
+		),
+		.target(
+			name: "FueledUtilsUIKit",
+			dependencies: ["FueledUtilsCore"],
+			path: "FueledUtils/UIKit"
+		),
+		.target(
+			name: "FueledUtilsReactiveSwiftUIKit",
+			dependencies: ["FueledUtilsReactiveSwift", "FueledUtilsUIKit"],
+			path: "FueledUtils/ReactiveSwiftUIKit"
+		),
+		.target(
+			name: "FueledUtilsCombine",
+			dependencies: ["FueledUtilsReactiveCommon"],
+			path: "FueledUtils/Combine"
+		),
+		.target(
+			name: "FueledUtilsCombineOperators",
+			dependencies: ["FueledUtilsCombine"],
+			path: "FueledUtils/CombineOperators"
+		),
+		.target(
+			name: "FueledUtilsCombineUIKit",
+			dependencies: ["FueledUtilsCombine", "FueledUtilsUIKit"],
+			path: "FueledUtils/CombineUIKit"
+		),
+		.target(
+			name: "FueledUtilsSwiftUI",
+			dependencies: ["FueledUtilsCombine", "FueledUtilsCore"],
+			path: "FueledUtils/SwiftUI"
+		),
+		.target(
+			name: "FueledUtilsReactiveCombineBridge",
+			dependencies: ["FueledUtilsCombine", "FueledUtilsReactiveSwift"],
+			path: "FueledUtils/ReactiveCombineBridge"
+		),
+	]
+)

--- a/Tests/FueledUtils.xcodeproj/project.pbxproj
+++ b/Tests/FueledUtils.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		F453AA832538E05E008F045B /* ReactiveCoalescingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F463C73A241835DD000A0B29 /* ReactiveCoalescingActionSpec.swift */; };
 		F453AA842538E05E008F045B /* ReactiveOverridingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429742925378348004BFA85 /* ReactiveOverridingActionSpec.swift */; };
 		F453AA892538EF16008F045B /* SinkForLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F453AA882538EF16008F045B /* SinkForLifetimeSpec.swift */; };
+		FC204075279EE4C9001A767C /* AnyCurrentValuePublisherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC204074279EE4C9001A767C /* AnyCurrentValuePublisherSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +47,7 @@
 		F46D2DA5252E4E4A00B6987A /* OrderedSetSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedSetSpec.swift; sourceTree = "<group>"; };
 		F499631F2537459200E2D4B5 /* CoalescingActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoalescingActionSpec.swift; sourceTree = "<group>"; };
 		F7F10FE9C8384333882C2368 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		FC204074279EE4C9001A767C /* AnyCurrentValuePublisherSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCurrentValuePublisherSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +123,7 @@
 		F463C739241835DD000A0B29 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				FC204074279EE4C9001A767C /* AnyCurrentValuePublisherSpec.swift */,
 				F499631F2537459200E2D4B5 /* CoalescingActionSpec.swift */,
 				F46D2DA5252E4E4A00B6987A /* OrderedSetSpec.swift */,
 				F429742D25378425004BFA85 /* OverridingActionSpec.swift */,
@@ -265,6 +268,7 @@
 			files = (
 				F453AA7B2538DE55008F045B /* CombineLatestManySpec.swift in Sources */,
 				F453AA802538E05E008F045B /* OrderedSetSpec.swift in Sources */,
+				FC204075279EE4C9001A767C /* AnyCurrentValuePublisherSpec.swift in Sources */,
 				F453AA892538EF16008F045B /* SinkForLifetimeSpec.swift in Sources */,
 				F453AA822538E05E008F045B /* OverridingActionSpec.swift in Sources */,
 				F453AA832538E05E008F045B /* ReactiveCoalescingActionSpec.swift in Sources */,

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -5,7 +5,7 @@ abstract_target 'Common' do
 		platform :ios, '13.0'
 
 		pod 'Quick', '~> 2.0'
-		pod 'Nimble', '~> 8.0'
+		pod 'Nimble', '~> 9.0'
 
 		pod 'FueledUtils/ReactiveCombineBridge', path: '../'
 		pod 'FueledUtils/ReactiveSwift', path: '../'

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,30 +1,30 @@
 PODS:
-  - FueledUtils/Combine (3.0-alpha1):
+  - FueledUtils/Combine (3.0-alpha3):
     - FueledUtils/ReactiveCommon
-  - FueledUtils/CombineOperators (3.0-alpha1):
+  - FueledUtils/CombineOperators (3.0-alpha3):
     - FueledUtils/Combine
-  - FueledUtils/CombineUIKit (3.0-alpha1):
+  - FueledUtils/CombineUIKit (3.0-alpha3):
     - FueledUtils/Combine
     - FueledUtils/UIKit
-  - FueledUtils/Core (3.0-alpha1)
-  - FueledUtils/ReactiveCombineBridge (3.0-alpha1):
+  - FueledUtils/Core (3.0-alpha3)
+  - FueledUtils/ReactiveCombineBridge (3.0-alpha3):
     - FueledUtils/Combine
     - FueledUtils/ReactiveSwift
-  - FueledUtils/ReactiveCommon (3.0-alpha1):
+  - FueledUtils/ReactiveCommon (3.0-alpha3):
     - FueledUtils/Core
-  - FueledUtils/ReactiveSwift (3.0-alpha1):
+  - FueledUtils/ReactiveSwift (3.0-alpha3):
     - FueledUtils/ReactiveCommon
     - ReactiveCocoa (~> 10.0)
     - ReactiveSwift (~> 6.0)
-  - FueledUtils/ReactiveSwiftUIKit (3.0-alpha1):
+  - FueledUtils/ReactiveSwiftUIKit (3.0-alpha3):
     - FueledUtils/ReactiveSwift
     - FueledUtils/UIKit
-  - FueledUtils/SwiftUI (3.0-alpha1):
+  - FueledUtils/SwiftUI (3.0-alpha3):
     - FueledUtils/Combine
     - FueledUtils/Core
-  - FueledUtils/UIKit (3.0-alpha1):
+  - FueledUtils/UIKit (3.0-alpha3):
     - FueledUtils/Core
-  - Nimble (8.0.5)
+  - Nimble (9.2.1)
   - Quick (2.2.0)
   - ReactiveCocoa (10.3.0):
     - ReactiveSwift (~> 6.2)
@@ -37,7 +37,7 @@ DEPENDENCIES:
   - FueledUtils/ReactiveSwift (from `../`)
   - FueledUtils/ReactiveSwiftUIKit (from `../`)
   - FueledUtils/SwiftUI (from `../`)
-  - Nimble (~> 8.0)
+  - Nimble (~> 9.0)
   - Quick (~> 2.0)
 
 SPEC REPOS:
@@ -52,12 +52,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FueledUtils: aa4b2a1e780f4f7e870ad53b64d0d7d16ab78604
-  Nimble: 4ab1aeb9b45553c75b9687196b0fa0713170a332
+  FueledUtils: e9de098eca826c389f818cf3ef259ffb1d397eb1
+  Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
   ReactiveCocoa: 083ae559e6f588ce519cab412ea119b431c26a24
   ReactiveSwift: 7555791a608c0679563a3f72546f971b2a06de98
 
-PODFILE CHECKSUM: 57c718acafcbfdffd0d4c0cd376a0088c9cc4812
+PODFILE CHECKSUM: d7dfdb27266ecccb25fe117e52721c9b19977a13
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.2

--- a/Tests/Tests/AnyCurrentValuePublisherSpec.swift
+++ b/Tests/Tests/AnyCurrentValuePublisherSpec.swift
@@ -12,48 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Quick
-import Nimble
+#if canImport(Combine)
+import Combine
 #if canImport(FueledUtilsCombine)
 import FueledUtilsCombine
 #elseif canImport(FueledUtils)
 import FueledUtils
 #endif
 import Foundation
-import ReactiveSwift
-#if canImport(Combine)
-import Combine
+import Quick
+import Nimble
 
-class SinkForLifetimeSpec: QuickSpec {
+class AnyCurrentValuePublisherSpec: QuickSpec {
 	override func spec() {
-		describe("sinkForLifeTimeOf()") {
-			it("should cancel itself automatically when the object becomes out of scope") {
-				var object: NSObject!
-				var valueCount = 0
-				var cancelCount = 0
-				do {
-					object = NSObject()
-					Timer.publish(every: 0.42, on: .current, in: .common)
-						.autoconnect()
-						.handleEvents(
-							receiveCancel: {
-								cancelCount += 1
-							}
-						)
-						.sinkForLifetimeOf(object) { _ in
-							valueCount += 1
-						}
+		describe("AnyCurrentValuePublisherSpec") {
+			describe("Initialization") {
+				it("Should initialize with a stored value") {
+					let publisher = AnyCurrentValuePublisher<Int, Never>(1)
+					expect(publisher.value) == 1
 				}
-
-				DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-					object = nil
+				it("Should initialize with a nested CurrentValueSubject") {
+					let subject = CurrentValueSubject<Int, Never>(2)
+					let publisher = AnyCurrentValuePublisher(subject)
+					expect(publisher.value) == 2
 				}
-
-				expect(valueCount).toEventually(equal(2))
-				expect(cancelCount).toEventually(equal(1), timeout: .seconds(2))
 			}
 		}
 	}
 }
-
 #endif

--- a/Tests/Tests/CoalescingActionSpec.swift
+++ b/Tests/Tests/CoalescingActionSpec.swift
@@ -14,7 +14,12 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsCombine)
+import FueledUtilsCombine
+#elseif canImport(FueledUtils)
 import FueledUtils
+#endif
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Tests/CombineLatestManySpec.swift
+++ b/Tests/Tests/CombineLatestManySpec.swift
@@ -14,7 +14,12 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsCombine)
+import FueledUtilsCombine
+#elseif canImport(FueledUtils)
 import FueledUtils
+#endif
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Tests/OrderedSetSpec.swift
+++ b/Tests/Tests/OrderedSetSpec.swift
@@ -14,7 +14,11 @@
 
 import Quick
 import Nimble
+#if canImport(FueledUtilsCore)
+import FueledUtilsCore
+#elseif canImport(FueledUtils)
 import FueledUtils
+#endif
 import XCTest
 
 class OrderedSetSpec: QuickSpec {

--- a/Tests/Tests/OverridingActionSpec.swift
+++ b/Tests/Tests/OverridingActionSpec.swift
@@ -56,8 +56,8 @@ class OverridingActionSpec: QuickSpec {
 					expect(cancelledCounter) == publishersCount - 1
 					expect(interruptedCounter) == publishersCount - 1
 
-					expect(cancelledCounter).toEventually(equal(publishersCount - 1), timeout: 2.0)
-					expect(cancelledCounter).toEventually(equal(interruptedCounter), timeout: 2.0)
+					expect(cancelledCounter).toEventually(equal(publishersCount - 1), timeout: .seconds(2))
+					expect(cancelledCounter).toEventually(equal(interruptedCounter), timeout: .seconds(2))
 				}
 			}
 		}

--- a/Tests/Tests/OverridingActionSpec.swift
+++ b/Tests/Tests/OverridingActionSpec.swift
@@ -14,7 +14,12 @@
 
 #if canImport(Combine)
 import Combine
+#if canImport(FueledUtilsCombine)
+import FueledUtilsCombine
+#elseif canImport(FueledUtils)
 import FueledUtils
+#endif
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Tests/ReactiveCoalescingActionSpec.swift
+++ b/Tests/Tests/ReactiveCoalescingActionSpec.swift
@@ -14,7 +14,12 @@
 
 import Quick
 import Nimble
+#if canImport(FueledUtilsReactiveSwift)
+import FueledUtilsReactiveSwift
+#elseif canImport(FueledUtils)
 import FueledUtils
+#endif
+import Foundation
 import ReactiveSwift
 
 class ReactiveCoalescingActionSpec: QuickSpec {

--- a/Tests/Tests/ReactiveOverridingActionSpec.swift
+++ b/Tests/Tests/ReactiveOverridingActionSpec.swift
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 import Quick
+#if canImport(FueledUtilsReactiveSwift)
+import FueledUtilsReactiveSwift
+#elseif canImport(FueledUtils)
 import FueledUtils
+#endif
+import Foundation
 import Nimble
 import ReactiveSwift
 

--- a/Tests/Tests/ReactiveOverridingActionSpec.swift
+++ b/Tests/Tests/ReactiveOverridingActionSpec.swift
@@ -50,11 +50,11 @@ class ReactiveOverridingActionSpec: QuickSpec {
 					}
 
 					expect(startCounter) == producersCount
-					expect(disposeCounter).toEventually(equal(producersCount - 1), timeout: 0.01)
-					expect(interruptedCounter).toEventually(equal(producersCount - 1), timeout: 0.01)
+					expect(disposeCounter).toEventually(equal(producersCount - 1), timeout: .milliseconds(10))
+					expect(interruptedCounter).toEventually(equal(producersCount - 1), timeout: .milliseconds(10))
 
-					expect(disposeCounter).toEventually(equal(producersCount), timeout: 2.0)
-					expect(interruptedCounter).toEventually(equal(producersCount - 1), timeout: 2.0)
+					expect(disposeCounter).toEventually(equal(producersCount), timeout: .seconds(2))
+					expect(interruptedCounter).toEventually(equal(producersCount - 1), timeout: .seconds(2))
 				}
 			}
 		}

--- a/Tests/Tests/ReactiveSwiftExtensionsSpec.swift
+++ b/Tests/Tests/ReactiveSwiftExtensionsSpec.swift
@@ -14,7 +14,12 @@
 
 import Quick
 import Nimble
+#if canImport(FueledUtilsReactiveSwift)
+import FueledUtilsReactiveSwift
+#elseif canImport(FueledUtils)
 import FueledUtils
+#endif
+import Foundation
 import ReactiveSwift
 
 class ReactiveSwiftExtensionsSpec: QuickSpec {

--- a/Tests/Tests/ReactiveSwiftExtensionsSpec.swift
+++ b/Tests/Tests/ReactiveSwiftExtensionsSpec.swift
@@ -33,7 +33,7 @@ class ReactiveSwiftExtensionsSpec: QuickSpec {
 
 					expect(valuesReceived) == 0
 
-					expect(valuesReceived).toEventually(equal(1), timeout: 1.0)
+					expect(valuesReceived).toEventually(equal(1), timeout: .seconds(1))
 
 					observer.send(value: ())
 
@@ -51,7 +51,7 @@ class ReactiveSwiftExtensionsSpec: QuickSpec {
 
 					expect(errorsReceived) == 0
 
-					expect(errorsReceived).toEventually(equal(1), timeout: 1.0)
+					expect(errorsReceived).toEventually(equal(1), timeout: .seconds(1))
 				}
 				it("should send any values instantly and receive an interrupted event if interrupted before the minimum interval is met") {
 					let (signal, observer) = Signal<Void, Never>.pipe()

--- a/Tests/Tests/SinkForLifetimeSpec.swift
+++ b/Tests/Tests/SinkForLifetimeSpec.swift
@@ -45,7 +45,7 @@ class SinkForLifetimeSpec: QuickSpec {
 				}
 
 				expect(valueCount).toEventually(equal(2))
-				expect(cancelCount).toEventually(equal(1), timeout: 2.0)
+				expect(cancelCount).toEventually(equal(1), timeout: .seconds(2))
 			}
 		}
 	}


### PR DESCRIPTION
### Goals :soccer:
Add **Swift Package Manager** support while preserving CocaPods support.

### Backwards-compatibility:

Everything should be backwards compatible.

### Implementation Details :construction:
Because Swift Package Manager has no way to prevent namespace collisions, I had to prefix all targets with `FueledUtils`. For instance, `ReactiveSwift` from **FueledUtils** would collide with the actual `ReactiveSwift` framework, hence the `FueledUtilsReactiveSwift` naming for this part of the library. Let me know if there is any workaround I haven't thought of.

### Testing Details :mag:
* All the tests are being run by the `swift test` command, ensuring it leverages the Swift Package Manager pipeline and the **FueledUtils** libraries.

* Nimble had to be updated to be compatible with Xcode 13+
